### PR TITLE
makefile: add go arch env variable for integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,4 +40,4 @@ test_unit:
 
 # GOARCH=amd64 is required to run the integration tests in gossamer
 test_integration:
-	@GOARCH=amd64 go test --tags="nonwasmenv" -v ./runtime/... -timeout 1500s
+	@GOARCH=amd64 go test --tags="nonwasmenv" -v ./runtime/... -timeout 2000s

--- a/Makefile
+++ b/Makefile
@@ -38,5 +38,6 @@ test: test_unit test_integration
 test_unit:
 	@go test --tags "nonwasmenv" -v `go list ./... | grep -v runtime`
 
+# GOARCH=amd64 is required to run the integration tests in gossamer
 test_integration:
-	@go test --tags="nonwasmenv" -v ./runtime/... -timeout 1500s
+	@GOARCH=amd64 go test --tags="nonwasmenv" -v ./runtime/... -timeout 1500s


### PR DESCRIPTION
**Detailed description**:
* [x] Set the `GOARCH=amd64` only for the integration tests. There is no need to mess up the correctly set local go env variables, which could cause other issues.
* [x] increase the timeout in integration tests

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated