### PR TITLE
revert Go version to 1.19 which is still supported by tinygo 0.25.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,12 @@ build:
 		echo "build - tinygo version: ${TAG}, gc: extallocleak"; \
 	fi
 
+build-local:
+	@cd tinygo; \
+		go install;
+	@tinygo version
+	@tinygo build -target=polkawasm -o=$(BUILD_PATH) runtime/runtime.go
+
 start-network:
 	cp build/runtime.wasm substrate/bin/node-template/runtime.wasm; \
 	cd substrate/bin/node-template; \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/LimeChain/gosemble
 
-go 1.20
+go 1.19
 
 require (
 	github.com/ChainSafe/gossamer v0.7.1-0.20230117201132-e6da01b2f323


### PR DESCRIPTION
**Detailed description**:
* [x] reverts Go version to 1.19 (still supported by TinyGo 0.25.0)
* [x] add build step without docker 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated