### PR TITLE
test(primitives/types): lookup

### DIFF
--- a/execution/types/unchecked_extrinsic.go
+++ b/execution/types/unchecked_extrinsic.go
@@ -94,11 +94,11 @@ func (uxt uncheckedExtrinsic) IsSigned() bool {
 	return bool(uxt.signature.HasValue)
 }
 
-func (uxt uncheckedExtrinsic) Check(lookup primitives.AccountIdLookup) (primitives.CheckedExtrinsic, primitives.TransactionValidityError) {
+func (uxt uncheckedExtrinsic) Check() (primitives.CheckedExtrinsic, primitives.TransactionValidityError) {
 	if uxt.signature.HasValue {
 		signer, signature, extra := uxt.signature.Value.Signer, uxt.signature.Value.Signature, uxt.signature.Value.Extra
 
-		signerAddress, err := lookup.Lookup(signer)
+		signerAddress, err := primitives.Lookup(signer)
 		if err != nil {
 			return nil, err
 		}

--- a/execution/types/unchecked_extrinsic_test.go
+++ b/execution/types/unchecked_extrinsic_test.go
@@ -54,17 +54,6 @@ var (
 		VaryingData: sc.NewVaryingData(sc.U8(3), signatureEd25519),
 	}
 
-	additionalSigned = sc.NewVaryingData(
-		types.H256{
-			FixedSequence: sc.FixedSequence[sc.U8]{
-				0x37, 0x37, 0x37, 0x37, 0x37, 0x37, 0x37, 0x37, 0x37, 0x37,
-				0x37, 0x37, 0x37, 0x37, 0x37, 0x37, 0x37, 0x37, 0x37, 0x37,
-				0x37, 0x37, 0x37, 0x37, 0x37, 0x37, 0x37, 0x37, 0x37, 0x37,
-				0x37, 0x37,
-			},
-		},
-	)
-
 	encodedPayloadBytes = []byte{0x38, 0x38, 0x38}
 )
 
@@ -74,18 +63,16 @@ var (
 
 	extrinsicSignature sc.Option[types.ExtrinsicSignature]
 
-	mockCall            *mocks.Call
-	mockSignedExtra     *mocks.SignedExtra
-	mockAccountIdLookup *mocks.AccountIdLookup
-	mocksSignedPayload  *mocks.SignedPayload
-	mockCrypto          *mocks.IoCrypto
-	mockHashing         *mocks.IoHashing
+	mockCall           *mocks.Call
+	mockSignedExtra    *mocks.SignedExtra
+	mocksSignedPayload *mocks.SignedPayload
+	mockCrypto         *mocks.IoCrypto
+	mockHashing        *mocks.IoHashing
 )
 
 func setup(signature types.MultiSignature) {
 	mockCall = new(mocks.Call)
 	mockSignedExtra = new(mocks.SignedExtra)
-	mockAccountIdLookup = new(mocks.AccountIdLookup)
 	mocksSignedPayload = new(mocks.SignedPayload)
 	mockCrypto = new(mocks.IoCrypto)
 	mockHashing = new(mocks.IoHashing)
@@ -234,9 +221,7 @@ func Test_Check_UnsignedUncheckedExtrinsic(t *testing.T) {
 	setup(signatureEd25519)
 	expect := NewCheckedExtrinsic(sc.NewOption[types.Address32](nil), mockCall, types.SignedExtra(nil)).(checkedExtrinsic)
 
-	lookup := types.DefaultAccountIdLookup()
-
-	result, err := targetUnsigned.Check(lookup)
+	result, err := targetUnsigned.Check()
 
 	assert.Nil(t, err)
 	checked := result.(checkedExtrinsic)
@@ -247,13 +232,11 @@ func Test_Check_UnsignedUncheckedExtrinsic(t *testing.T) {
 
 func Test_Check_SignedUncheckedExtrinsic_LookupError(t *testing.T) {
 	setup(signatureEd25519)
+	invalidAccountId := sc.U8(10)
 
-	mockAccountIdLookup.On("Lookup", extrinsicSignature.Value.Signer).
-		Return(types.Address32{}, unknownTransactionCannotLookupError)
+	targetSigned.signature.Value.Signer = types.MultiAddress{VaryingData: sc.NewVaryingData(invalidAccountId)}
+	res, err := targetSigned.Check()
 
-	res, err := targetSigned.Check(mockAccountIdLookup)
-
-	mockAccountIdLookup.AssertCalled(t, "Lookup", extrinsicSignature.Value.Signer)
 	mockSignedExtra.AssertNotCalled(t, "AdditionalSigned")
 	mocksSignedPayload.AssertNotCalled(t, "UsingEncoded")
 	mockCrypto.AssertNotCalled(t, "Ed25519Verify", mock.Anything, mock.Anything, mock.Anything)
@@ -265,12 +248,10 @@ func Test_Check_SignedUncheckedExtrinsic_AncientBirthBlockError(t *testing.T) {
 	setup(signatureEd25519)
 
 	targetSigned.initializePayload = types.NewSignedPayload
-	mockAccountIdLookup.On("Lookup", extrinsicSignature.Value.Signer).Return(signerAddress, nil)
 	mockSignedExtra.On("AdditionalSigned").Return(types.AdditionalSigned{}, invalidTransactionAncientBirthBlockError)
 
-	res, err := targetSigned.Check(mockAccountIdLookup)
+	res, err := targetSigned.Check()
 
-	mockAccountIdLookup.AssertCalled(t, "Lookup", extrinsicSignature.Value.Signer)
 	mockSignedExtra.AssertCalled(t, "AdditionalSigned")
 	mocksSignedPayload.AssertNotCalled(t, "UsingEncoded")
 	mockCrypto.AssertNotCalled(t, "Ed25519Verify", mock.Anything, mock.Anything, mock.Anything)
@@ -281,13 +262,11 @@ func Test_Check_SignedUncheckedExtrinsic_AncientBirthBlockError(t *testing.T) {
 func Test_Check_SignedUncheckedExtrinsic_BadProofError(t *testing.T) {
 	setup(signatureEd25519)
 
-	mockAccountIdLookup.On("Lookup", extrinsicSignature.Value.Signer).Return(signerAddress, nil)
 	mocksSignedPayload.On("Bytes").Return(encodedPayloadBytes)
 	mockCrypto.On("Ed25519Verify", signatureBytes, encodedPayloadBytes, signerAddressBytes).Return(false)
 
-	res, err := targetSigned.Check(mockAccountIdLookup)
+	res, err := targetSigned.Check()
 
-	mockAccountIdLookup.AssertCalled(t, "Lookup", extrinsicSignature.Value.Signer)
 	mocksSignedPayload.AssertCalled(t, "Bytes")
 	mockHashing.AssertNotCalled(t, "Blake256", mock.Anything)
 	mockCrypto.AssertCalled(t, "Ed25519Verify", signatureBytes, encodedPayloadBytes, signerAddressBytes)
@@ -301,14 +280,12 @@ func Test_Check_SignedUncheckedExtrinsic_LongEncoding_BadProofError(t *testing.T
 	signedPayloadBytes := make([]byte, 257)
 	blakeHashBytes := []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09}
 
-	mockAccountIdLookup.On("Lookup", extrinsicSignature.Value.Signer).Return(signerAddress, nil)
 	mocksSignedPayload.On("Bytes").Return(signedPayloadBytes)
 	mockHashing.On("Blake256", signedPayloadBytes).Return(blakeHashBytes)
 	mockCrypto.On("Ed25519Verify", signatureBytes, blakeHashBytes, signerAddressBytes).Return(false)
 
-	res, err := targetSigned.Check(mockAccountIdLookup)
+	res, err := targetSigned.Check()
 
-	mockAccountIdLookup.AssertCalled(t, "Lookup", extrinsicSignature.Value.Signer)
 	mocksSignedPayload.AssertCalled(t, "Bytes")
 	mockHashing.AssertCalled(t, "Blake256", signedPayloadBytes)
 	mockCrypto.AssertCalled(t, "Ed25519Verify", signatureBytes, blakeHashBytes, signerAddressBytes)
@@ -320,11 +297,10 @@ func Test_Check_SignedUncheckedExtrinsic_Success(t *testing.T) {
 	setup(signatureEd25519)
 	expect := NewCheckedExtrinsic(sc.NewOption[types.Address32](signerAddress), mockCall, mockSignedExtra).(checkedExtrinsic)
 
-	mockAccountIdLookup.On("Lookup", extrinsicSignature.Value.Signer).Return(signerAddress, nil)
 	mocksSignedPayload.On("Bytes").Return(encodedPayloadBytes)
 	mockCrypto.On("Ed25519Verify", signatureBytes, encodedPayloadBytes, signerAddressBytes).Return(true)
 
-	result, err := targetSigned.Check(mockAccountIdLookup)
+	result, err := targetSigned.Check()
 
 	assert.Nil(t, err)
 	checked := result.(checkedExtrinsic)
@@ -332,7 +308,6 @@ func Test_Check_SignedUncheckedExtrinsic_Success(t *testing.T) {
 	assert.Equal(t, expect.signer, checked.signer)
 	assert.Equal(t, expect.function, checked.function)
 
-	mockAccountIdLookup.AssertCalled(t, "Lookup", extrinsicSignature.Value.Signer)
 	mocksSignedPayload.AssertCalled(t, "Bytes")
 	mockHashing.AssertNotCalled(t, "Blake256", mock.Anything)
 	mockCrypto.AssertCalled(t, "Ed25519Verify", signatureBytes, encodedPayloadBytes, signerAddressBytes)
@@ -342,11 +317,10 @@ func Test_Check_SignedUncheckedExtrinsic_Success_Sr25519(t *testing.T) {
 	setup(signatureSr25519)
 	expect := NewCheckedExtrinsic(sc.NewOption[types.Address32](signerAddress), mockCall, mockSignedExtra).(checkedExtrinsic)
 
-	mockAccountIdLookup.On("Lookup", extrinsicSignature.Value.Signer).Return(signerAddress, nil)
 	mocksSignedPayload.On("Bytes").Return(encodedPayloadBytes)
 	mockCrypto.On("Sr25519Verify", signatureBytes, encodedPayloadBytes, signerAddressBytes).Return(true)
 
-	result, err := targetSigned.Check(mockAccountIdLookup)
+	result, err := targetSigned.Check()
 
 	assert.Nil(t, err)
 	checked := result.(checkedExtrinsic)
@@ -354,7 +328,6 @@ func Test_Check_SignedUncheckedExtrinsic_Success_Sr25519(t *testing.T) {
 	assert.Equal(t, expect.signer, checked.signer)
 	assert.Equal(t, expect.function, checked.function)
 
-	mockAccountIdLookup.AssertCalled(t, "Lookup", extrinsicSignature.Value.Signer)
 	mocksSignedPayload.AssertCalled(t, "Bytes")
 	mockHashing.AssertNotCalled(t, "Blake256", mock.Anything)
 	mockCrypto.AssertCalled(t, "Sr25519Verify", signatureBytes, encodedPayloadBytes, signerAddressBytes)
@@ -363,14 +336,12 @@ func Test_Check_SignedUncheckedExtrinsic_Success_Sr25519(t *testing.T) {
 func Test_Check_SignedUncheckedExtrinsic_UnknownSignatureType(t *testing.T) {
 	setup(unknownMultisignature)
 
-	mockAccountIdLookup.On("Lookup", extrinsicSignature.Value.Signer).Return(signerAddress, nil)
 	mocksSignedPayload.On("Bytes").Return(encodedPayloadBytes)
 
 	assert.PanicsWithValue(t, "invalid MultiSignature type in Verify", func() {
-		targetSigned.Check(mockAccountIdLookup)
+		targetSigned.Check()
 	})
 
-	mockAccountIdLookup.AssertCalled(t, "Lookup", extrinsicSignature.Value.Signer)
 	mocksSignedPayload.AssertCalled(t, "Bytes")
 	mockHashing.AssertNotCalled(t, "Blake256", mock.Anything)
 	mockCrypto.AssertNotCalled(t, "Sr25519Verify", mock.Anything, mock.Anything, mock.Anything)

--- a/frame/balances/call_force_free.go
+++ b/frame/balances/call_force_free.go
@@ -116,7 +116,7 @@ func (c callForceFree) forceFree(origin types.RawOrigin, who types.MultiAddress,
 		return types.NewDispatchErrorBadOrigin()
 	}
 
-	target, err := types.DefaultAccountIdLookup().Lookup(who)
+	target, err := types.Lookup(who)
 	if err != nil {
 		// TODO: there is an issue with fmt.Sprintf when compiled with the "custom gc"
 		// log.Debug(fmt.Sprintf("Failed to lookup [%s]", who.Bytes()))

--- a/frame/balances/call_force_transfer.go
+++ b/frame/balances/call_force_transfer.go
@@ -118,11 +118,11 @@ func (c callForceTransfer) forceTransfer(origin types.RawOrigin, source types.Mu
 		return types.NewDispatchErrorBadOrigin()
 	}
 
-	sourceAddress, err := types.DefaultAccountIdLookup().Lookup(source)
+	sourceAddress, err := types.Lookup(source)
 	if err != nil {
 		return types.NewDispatchErrorCannotLookup()
 	}
-	destinationAddress, err := types.DefaultAccountIdLookup().Lookup(dest)
+	destinationAddress, err := types.Lookup(dest)
 	if err != nil {
 		return types.NewDispatchErrorCannotLookup()
 	}

--- a/frame/balances/call_set_balance.go
+++ b/frame/balances/call_set_balance.go
@@ -132,7 +132,7 @@ func (c callSetBalance) setBalance(origin types.RawOrigin, who types.MultiAddres
 		return types.NewDispatchErrorBadOrigin()
 	}
 
-	address, err := types.DefaultAccountIdLookup().Lookup(who)
+	address, err := types.Lookup(who)
 	if err != nil {
 		return types.NewDispatchErrorCannotLookup()
 	}

--- a/frame/balances/call_transfer.go
+++ b/frame/balances/call_transfer.go
@@ -133,7 +133,7 @@ func (t transfer) transfer(origin types.RawOrigin, dest types.MultiAddress, valu
 		return types.NewDispatchErrorBadOrigin()
 	}
 
-	to, err := types.DefaultAccountIdLookup().Lookup(dest)
+	to, err := types.Lookup(dest)
 	if err != nil {
 		return types.NewDispatchErrorCannotLookup()
 	}

--- a/frame/balances/call_transfer_all.go
+++ b/frame/balances/call_transfer_all.go
@@ -122,7 +122,7 @@ func (c callTransferAll) transferAll(origin types.RawOrigin, dest types.MultiAdd
 		return primitives.NewDispatchErrorOther(sc.Str(err.Error()))
 	}
 
-	to, errLookup := types.DefaultAccountIdLookup().Lookup(dest)
+	to, errLookup := types.Lookup(dest)
 	if errLookup != nil {
 		// TODO: there is an issue with fmt.Sprintf when compiled with the "custom gc"
 		// log.Debug(fmt.Sprintf("Failed to lookup [%s]", dest.Bytes()))

--- a/frame/balances/call_transfer_keep_alive.go
+++ b/frame/balances/call_transfer_keep_alive.go
@@ -113,7 +113,7 @@ func (c callTransferKeepAlive) transferKeepAlive(origin types.RawOrigin, dest ty
 	}
 	transactor := origin.AsSigned()
 
-	address, err := types.DefaultAccountIdLookup().Lookup(dest)
+	address, err := types.Lookup(dest)
 	if err != nil {
 		return types.NewDispatchErrorCannotLookup()
 	}

--- a/frame/executive/executive.go
+++ b/frame/executive/executive.go
@@ -101,7 +101,7 @@ func (m module) ApplyExtrinsic(uxt primitives.UncheckedExtrinsic) (primitives.Di
 	log.Trace("apply_extrinsic")
 
 	// Verify that the signature is good.
-	checked, err := uxt.Check(primitives.DefaultAccountIdLookup())
+	checked, err := uxt.Check()
 	if err != nil {
 		return primitives.DispatchOutcome{}, err
 	}
@@ -177,7 +177,7 @@ func (m module) ValidateTransaction(source primitives.TransactionSource, uxt pri
 	encodedLen := sc.ToCompact(len(uxt.Bytes()))
 
 	log.Trace("check")
-	checked, errCheck := uxt.Check(primitives.DefaultAccountIdLookup())
+	checked, errCheck := uxt.Check()
 	if errCheck != nil {
 		return primitives.ValidTransaction{}, errCheck
 	}

--- a/frame/executive/executive_test.go
+++ b/frame/executive/executive_test.go
@@ -65,8 +65,6 @@ var (
 
 	unsignedValidator primitives.UnsignedValidator
 
-	defaultAccountIdLookup = primitives.DefaultAccountIdLookup()
-
 	txSource = primitives.NewTransactionSourceExternal()
 
 	defaultDigest = primitives.Digest{}
@@ -319,7 +317,7 @@ func Test_Executive_ApplyExtrinsic_UnknownTransactionCannotLookupError(t *testin
 	setup()
 
 	mockUncheckedExtrinsic.On("Bytes").Return(encodedExtrinsic)
-	mockUncheckedExtrinsic.On("Check", defaultAccountIdLookup).Return(nil, unknownTransactionCannotLookupError)
+	mockUncheckedExtrinsic.On("Check").Return(nil, unknownTransactionCannotLookupError)
 
 	outcome, err := target.ApplyExtrinsic(mockUncheckedExtrinsic)
 
@@ -331,7 +329,7 @@ func Test_Executive_ApplyExtrinsic_InvalidTransactionExhaustsResourcesError(t *t
 	setup()
 
 	mockUncheckedExtrinsic.On("Bytes").Return(encodedExtrinsic)
-	mockUncheckedExtrinsic.On("Check", defaultAccountIdLookup).Return(mockCheckedExtrinsic, nil)
+	mockUncheckedExtrinsic.On("Check").Return(mockCheckedExtrinsic, nil)
 	mockSystemModule.On("NoteExtrinsic", mockUncheckedExtrinsic.Bytes())
 	mockCheckedExtrinsic.On("Function").Return(mockCall)
 	mockCall.On("BaseWeight").Return(baseWeight)
@@ -360,7 +358,7 @@ func Test_Executive_ApplyExtrinsic_InvalidTransactionBadMandatoryError(t *testin
 	}
 
 	mockUncheckedExtrinsic.On("Bytes").Return(encodedExtrinsic)
-	mockUncheckedExtrinsic.On("Check", defaultAccountIdLookup).Return(mockCheckedExtrinsic, nil)
+	mockUncheckedExtrinsic.On("Check").Return(mockCheckedExtrinsic, nil)
 	mockSystemModule.On("NoteExtrinsic", mockUncheckedExtrinsic.Bytes())
 	mockCheckedExtrinsic.On("Function").Return(mockCall)
 	mockCall.On("BaseWeight").Return(baseWeight)
@@ -381,7 +379,7 @@ func Test_Executive_ApplyExtrinsic_Success(t *testing.T) {
 	setup()
 
 	mockUncheckedExtrinsic.On("Bytes").Return(encodedExtrinsic)
-	mockUncheckedExtrinsic.On("Check", defaultAccountIdLookup).Return(mockCheckedExtrinsic, nil)
+	mockUncheckedExtrinsic.On("Check").Return(mockCheckedExtrinsic, nil)
 	mockSystemModule.On("NoteExtrinsic", mockUncheckedExtrinsic.Bytes())
 
 	mockCheckedExtrinsic.On("Function").Return(mockCall)
@@ -440,14 +438,14 @@ func Test_Executive_ValidateTransaction_UnknownTransactionCannotLookupError(t *t
 	mockSystemModule.On("StorageBlockNumber").Return(blockNumber, nil)
 	mockSystemModule.On("Initialize", blockNumber+1, header.ParentHash, defaultDigest)
 	mockUncheckedExtrinsic.On("Bytes").Return(encodedExtrinsic)
-	mockUncheckedExtrinsic.On("Check", defaultAccountIdLookup).Return(nil, unknownTransactionCannotLookupError)
+	mockUncheckedExtrinsic.On("Check").Return(nil, unknownTransactionCannotLookupError)
 
 	outcome, err := target.ValidateTransaction(txSource, mockUncheckedExtrinsic, header.ParentHash)
 
 	mockSystemModule.AssertCalled(t, "StorageBlockNumber")
 	mockSystemModule.AssertCalled(t, "Initialize", blockNumber+1, header.ParentHash, defaultDigest)
 	mockUncheckedExtrinsic.AssertCalled(t, "Bytes")
-	mockUncheckedExtrinsic.AssertCalled(t, "Check", defaultAccountIdLookup)
+	mockUncheckedExtrinsic.AssertCalled(t, "Check")
 	mockCheckedExtrinsic.AssertNotCalled(t, "Validate", unsignedValidator, txSource, &dispatchInfo, encodedExtrinsicLen)
 	assert.Equal(t, defaultValidTransaction, outcome)
 	assert.Equal(t, unknownTransactionCannotLookupError, err)
@@ -465,7 +463,7 @@ func Test_Executive_ValidateTransaction_InvalidTransactionMandatoryValidationErr
 	mockSystemModule.On("StorageBlockNumber").Return(blockNumber, nil)
 	mockSystemModule.On("Initialize", blockNumber+1, header.ParentHash, defaultDigest)
 	mockUncheckedExtrinsic.On("Bytes").Return(encodedExtrinsic)
-	mockUncheckedExtrinsic.On("Check", defaultAccountIdLookup).Return(mockCheckedExtrinsic, nil)
+	mockUncheckedExtrinsic.On("Check").Return(mockCheckedExtrinsic, nil)
 	mockCheckedExtrinsic.On("Function").Return(mockCall)
 	mockCall.On("BaseWeight").Return(baseWeight)
 	mockCall.On("WeighData", baseWeight).Return(dispatchInfo.Weight)
@@ -477,7 +475,7 @@ func Test_Executive_ValidateTransaction_InvalidTransactionMandatoryValidationErr
 	mockSystemModule.AssertCalled(t, "StorageBlockNumber")
 	mockSystemModule.AssertCalled(t, "Initialize", blockNumber+1, header.ParentHash, defaultDigest)
 	mockUncheckedExtrinsic.AssertCalled(t, "Bytes")
-	mockUncheckedExtrinsic.AssertCalled(t, "Check", defaultAccountIdLookup)
+	mockUncheckedExtrinsic.AssertCalled(t, "Check")
 	mockCheckedExtrinsic.AssertCalled(t, "Function")
 	mockCall.AssertCalled(t, "BaseWeight")
 	mockCall.AssertCalled(t, "WeighData", baseWeight)
@@ -494,7 +492,7 @@ func Test_Executive_ValidateTransaction(t *testing.T) {
 	mockSystemModule.On("StorageBlockNumber").Return(blockNumber, nil)
 	mockSystemModule.On("Initialize", blockNumber+1, header.ParentHash, defaultDigest)
 	mockUncheckedExtrinsic.On("Bytes").Return(encodedExtrinsic)
-	mockUncheckedExtrinsic.On("Check", defaultAccountIdLookup).Return(mockCheckedExtrinsic, transactionValidityError)
+	mockUncheckedExtrinsic.On("Check").Return(mockCheckedExtrinsic, transactionValidityError)
 	mockCheckedExtrinsic.On("Function").Return(mockCall)
 	mockCall.On("BaseWeight").Return(baseWeight)
 	mockCall.On("WeighData", baseWeight).Return(dispatchInfo.Weight)
@@ -508,7 +506,7 @@ func Test_Executive_ValidateTransaction(t *testing.T) {
 	mockSystemModule.AssertCalled(t, "StorageBlockNumber")
 	mockSystemModule.AssertCalled(t, "Initialize", blockNumber+1, header.ParentHash, defaultDigest)
 	mockUncheckedExtrinsic.AssertCalled(t, "Bytes")
-	mockUncheckedExtrinsic.AssertCalled(t, "Check", defaultAccountIdLookup)
+	mockUncheckedExtrinsic.AssertCalled(t, "Check")
 	mockCheckedExtrinsic.AssertCalled(t, "Function")
 	mockCall.AssertCalled(t, "BaseWeight")
 	mockCall.AssertCalled(t, "WeighData", baseWeight)

--- a/mocks/unchecked_extrinsic.go
+++ b/mocks/unchecked_extrinsic.go
@@ -41,8 +41,8 @@ func (uxt *UncheckedExtrinsic) IsSigned() bool {
 	return args.Get(0).(bool)
 }
 
-func (uxt *UncheckedExtrinsic) Check(lookup primitives.AccountIdLookup) (primitives.CheckedExtrinsic, primitives.TransactionValidityError) {
-	args := uxt.Called(lookup)
+func (uxt *UncheckedExtrinsic) Check() (primitives.CheckedExtrinsic, primitives.TransactionValidityError) {
+	args := uxt.Called()
 
 	var arg0 primitives.CheckedExtrinsic
 	var arg1 primitives.TransactionValidityError

--- a/primitives/types/lookup.go
+++ b/primitives/types/lookup.go
@@ -6,17 +6,17 @@ type AccountIdLookup interface {
 	Lookup(a MultiAddress) (Address32, TransactionValidityError)
 }
 
-// AccountIdLookup A lookup implementation returning the `AccountId` from a `MultiAddress`.
-type accountIdLookup struct { // TODO: make it generic [AccountId, AccountIndex]
-	// TODO: PhantomData[(AccountId, AccountIndex)]
-}
+//// AccountIdLookup A lookup implementation returning the `AccountId` from a `MultiAddress`.
+//type accountIdLookup struct { // TODO: make it generic [AccountId, AccountIndex]
+//	// TODO: PhantomData[(AccountId, AccountIndex)]
+//}
 
-func DefaultAccountIdLookup() accountIdLookup {
-	return accountIdLookup{}
-}
+//func DefaultAccountIdLookup() accountIdLookup {
+//	return accountIdLookup{}
+//}
 
 // TODO: MultiAddress[AccountId, AccountIndex]
-func (l accountIdLookup) Lookup(a MultiAddress) (Address32, TransactionValidityError) {
+func Lookup(a MultiAddress) (Address32, TransactionValidityError) {
 	address := lookupAddress(a)
 	if address.HasValue {
 		return address.Value, nil

--- a/primitives/types/lookup.go
+++ b/primitives/types/lookup.go
@@ -2,20 +2,6 @@ package types
 
 import sc "github.com/LimeChain/goscale"
 
-type AccountIdLookup interface {
-	Lookup(a MultiAddress) (Address32, TransactionValidityError)
-}
-
-//// AccountIdLookup A lookup implementation returning the `AccountId` from a `MultiAddress`.
-//type accountIdLookup struct { // TODO: make it generic [AccountId, AccountIndex]
-//	// TODO: PhantomData[(AccountId, AccountIndex)]
-//}
-
-//func DefaultAccountIdLookup() accountIdLookup {
-//	return accountIdLookup{}
-//}
-
-// TODO: MultiAddress[AccountId, AccountIndex]
 func Lookup(a MultiAddress) (Address32, TransactionValidityError) {
 	address := lookupAddress(a)
 	if address.HasValue {
@@ -26,7 +12,7 @@ func Lookup(a MultiAddress) (Address32, TransactionValidityError) {
 }
 
 // LookupAddress Lookup an address to get an Id, if there's one there.
-func lookupAddress(a MultiAddress) sc.Option[Address32] { // TODO: MultiAddress[AccountId, AccountIndex]
+func lookupAddress(a MultiAddress) sc.Option[Address32] {
 	if a.IsAccountId() {
 		return sc.NewOption[Address32](a.AsAccountId().Address32)
 	}
@@ -36,7 +22,7 @@ func lookupAddress(a MultiAddress) sc.Option[Address32] { // TODO: MultiAddress[
 	}
 
 	if a.IsAccountIndex() {
-		return sc.NewOption[Address32](lookupIndex(a.AsAccountIndex()))
+		return lookupIndex(a.AsAccountIndex())
 	}
 
 	return sc.NewOption[Address32](nil)

--- a/primitives/types/lookup_test.go
+++ b/primitives/types/lookup_test.go
@@ -1,0 +1,1 @@
+package types

--- a/primitives/types/lookup_test.go
+++ b/primitives/types/lookup_test.go
@@ -1,1 +1,48 @@
 package types
+
+import (
+	"testing"
+
+	sc "github.com/LimeChain/goscale"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	signerAccountId = NewMultiAddressId(
+		AccountId{
+			Address32: NewAddress32(sc.BytesToSequenceU8(signerAddressBytes)...),
+		},
+	)
+	signerAddress32 = NewMultiAddress32(
+		Address32{
+			sc.BytesToFixedSequenceU8(signerAddressBytes),
+		},
+	)
+	signerAccountIndex  = NewMultiAddressIndex(accountIndex)
+	expectedAccountId   = NewAddress32(sc.BytesToSequenceU8(signerAddressBytes)...)
+	invalidMultiAddress = MultiAddress{sc.NewVaryingData(sc.U8(5), sc.ToCompact(accountIndex))}
+)
+
+func Test_Lookup_AccountId(t *testing.T) {
+	result, err := Lookup(signerAccountId)
+	assert.Nil(t, err)
+	assert.Equal(t, result, expectedAccountId)
+}
+
+func Test_Lookup_Address32(t *testing.T) {
+	result, err := Lookup(signerAddress32)
+	assert.Nil(t, err)
+	assert.Equal(t, result, expectedAccountId)
+}
+
+func Test_Lookup_AccountIndex(t *testing.T) {
+	result, err := Lookup(signerAccountIndex)
+	assert.Equal(t, err, NewTransactionValidityError(NewUnknownTransactionCannotLookup()))
+	assert.Equal(t, result, Address32{})
+}
+
+func Test_Lookup_MultiAddress_NotValid(t *testing.T) {
+	result, err := Lookup(invalidMultiAddress)
+	assert.Equal(t, err, NewTransactionValidityError(NewUnknownTransactionCannotLookup()))
+	assert.Equal(t, result, Address32{})
+}

--- a/primitives/types/lookup_test.go
+++ b/primitives/types/lookup_test.go
@@ -8,35 +8,35 @@ import (
 )
 
 var (
-	signerAccountId = NewMultiAddressId(
+	multiAddressId = NewMultiAddressId(
 		AccountId{
 			Address32: NewAddress32(sc.BytesToSequenceU8(signerAddressBytes)...),
 		},
 	)
-	signerAddress32 = NewMultiAddress32(
+	multiAddress32 = NewMultiAddress32(
 		Address32{
 			sc.BytesToFixedSequenceU8(signerAddressBytes),
 		},
 	)
-	signerAccountIndex  = NewMultiAddressIndex(accountIndex)
+	multiAddressIndex   = NewMultiAddressIndex(accountIndex)
 	expectedAccountId   = NewAddress32(sc.BytesToSequenceU8(signerAddressBytes)...)
 	invalidMultiAddress = MultiAddress{sc.NewVaryingData(sc.U8(5), sc.ToCompact(accountIndex))}
 )
 
 func Test_Lookup_AccountId(t *testing.T) {
-	result, err := Lookup(signerAccountId)
+	result, err := Lookup(multiAddressId)
 	assert.Nil(t, err)
 	assert.Equal(t, result, expectedAccountId)
 }
 
 func Test_Lookup_Address32(t *testing.T) {
-	result, err := Lookup(signerAddress32)
+	result, err := Lookup(multiAddress32)
 	assert.Nil(t, err)
 	assert.Equal(t, result, expectedAccountId)
 }
 
 func Test_Lookup_AccountIndex(t *testing.T) {
-	result, err := Lookup(signerAccountIndex)
+	result, err := Lookup(multiAddressIndex)
 	assert.Equal(t, err, NewTransactionValidityError(NewUnknownTransactionCannotLookup()))
 	assert.Equal(t, result, Address32{})
 }

--- a/primitives/types/unchecked_extrinsic.go
+++ b/primitives/types/unchecked_extrinsic.go
@@ -10,5 +10,5 @@ type UncheckedExtrinsic interface {
 	Extra() SignedExtra
 
 	IsSigned() bool
-	Check(lookup AccountIdLookup) (CheckedExtrinsic, TransactionValidityError)
+	Check() (CheckedExtrinsic, TransactionValidityError)
 }


### PR DESCRIPTION
**Detailed description**:
- adds tests for the lookup type
- refactors lookup type to get rid of unused struct & interface
- refactors other tests that have mocked the unused struct & interface

**Which issue(s) this PR fixes**:
- part of #216 

**Checklist**
- [ ] Documentation added
- [x] Tests updated