### PR TITLE
refactor: remove logging calls from the primitive types

### DIFF
--- a/api/account_nonce/module.go
+++ b/api/account_nonce/module.go
@@ -32,7 +32,10 @@ func (m Module) Name() string {
 }
 
 func (m Module) Item() types.ApiItem {
-	hash := hashing.MustBlake2b8([]byte(ApiModuleName))
+	hash, err := hashing.MustBlake2b8([]byte(ApiModuleName))
+	if err != nil {
+		log.Critical(err.Error())
+	}
 	return types.NewApiItem(hash, apiVersion)
 }
 

--- a/api/account_nonce/module.go
+++ b/api/account_nonce/module.go
@@ -32,10 +32,7 @@ func (m Module) Name() string {
 }
 
 func (m Module) Item() types.ApiItem {
-	hash, err := hashing.Blake2b8([]byte(ApiModuleName))
-	if err != nil {
-		log.Critical(err.Error())
-	}
+	hash := hashing.MustBlake2b8([]byte(ApiModuleName))
 	return types.NewApiItem(hash, apiVersion)
 }
 

--- a/api/account_nonce/module.go
+++ b/api/account_nonce/module.go
@@ -32,7 +32,7 @@ func (m Module) Name() string {
 }
 
 func (m Module) Item() types.ApiItem {
-	hash, err := hashing.MustBlake2b8([]byte(ApiModuleName))
+	hash, err := hashing.Blake2b8([]byte(ApiModuleName))
 	if err != nil {
 		log.Critical(err.Error())
 	}

--- a/api/aura/module.go
+++ b/api/aura/module.go
@@ -31,7 +31,10 @@ func (m Module) Name() string {
 }
 
 func (m Module) Item() primitives.ApiItem {
-	hash := hashing.MustBlake2b8([]byte(ApiModuleName))
+	hash, err := hashing.MustBlake2b8([]byte(ApiModuleName))
+	if err != nil {
+		log.Critical(err.Error())
+	}
 	return primitives.NewApiItem(hash, apiVersion)
 }
 

--- a/api/aura/module.go
+++ b/api/aura/module.go
@@ -31,10 +31,7 @@ func (m Module) Name() string {
 }
 
 func (m Module) Item() primitives.ApiItem {
-	hash, err := hashing.Blake2b8([]byte(ApiModuleName))
-	if err != nil {
-		log.Critical(err.Error())
-	}
+	hash := hashing.MustBlake2b8([]byte(ApiModuleName))
 	return primitives.NewApiItem(hash, apiVersion)
 }
 

--- a/api/aura/module.go
+++ b/api/aura/module.go
@@ -31,7 +31,7 @@ func (m Module) Name() string {
 }
 
 func (m Module) Item() primitives.ApiItem {
-	hash, err := hashing.MustBlake2b8([]byte(ApiModuleName))
+	hash, err := hashing.Blake2b8([]byte(ApiModuleName))
 	if err != nil {
 		log.Critical(err.Error())
 	}

--- a/api/block_builder/module.go
+++ b/api/block_builder/module.go
@@ -45,7 +45,10 @@ func (m Module) Name() string {
 }
 
 func (m Module) Item() primitives.ApiItem {
-	hash := hashing.MustBlake2b8([]byte(ApiModuleName))
+	hash, err := hashing.MustBlake2b8([]byte(ApiModuleName))
+	if err != nil {
+		log.Critical(err.Error())
+	}
 	return primitives.NewApiItem(hash, apiVersion)
 }
 
@@ -68,9 +71,15 @@ func (m Module) ApplyExtrinsic(dataPtr int32, dataLen int32) int64 {
 	ok, errApplyExtr := m.executive.ApplyExtrinsic(uxt)
 	var applyExtrinsicResult primitives.ApplyExtrinsicResult
 	if errApplyExtr != nil {
-		applyExtrinsicResult = primitives.NewApplyExtrinsicResult(errApplyExtr)
+		applyExtrinsicResult, err = primitives.NewApplyExtrinsicResult(errApplyExtr)
+		if err != nil {
+			log.Critical(err.Error())
+		}
 	} else {
-		applyExtrinsicResult = primitives.NewApplyExtrinsicResult(ok)
+		applyExtrinsicResult, err = primitives.NewApplyExtrinsicResult(ok)
+		if err != nil {
+			log.Critical(err.Error())
+		}
 	}
 
 	buffer.Reset()

--- a/api/block_builder/module.go
+++ b/api/block_builder/module.go
@@ -45,10 +45,7 @@ func (m Module) Name() string {
 }
 
 func (m Module) Item() primitives.ApiItem {
-	hash, err := hashing.Blake2b8([]byte(ApiModuleName))
-	if err != nil {
-		log.Critical(err.Error())
-	}
+	hash := hashing.MustBlake2b8([]byte(ApiModuleName))
 	return primitives.NewApiItem(hash, apiVersion)
 }
 

--- a/api/block_builder/module.go
+++ b/api/block_builder/module.go
@@ -45,7 +45,7 @@ func (m Module) Name() string {
 }
 
 func (m Module) Item() primitives.ApiItem {
-	hash, err := hashing.MustBlake2b8([]byte(ApiModuleName))
+	hash, err := hashing.Blake2b8([]byte(ApiModuleName))
 	if err != nil {
 		log.Critical(err.Error())
 	}

--- a/api/block_builder/module_test.go
+++ b/api/block_builder/module_test.go
@@ -53,8 +53,11 @@ func Test_Module_ApplyExtrinsic_Success(t *testing.T) {
 	target := setup()
 
 	bufferUxt := bytes.NewBuffer(bUxt)
-	outcome := primitives.NewDispatchOutcome(sc.Empty{})
-	bExtrinsicResult := primitives.NewApplyExtrinsicResult(outcome).Bytes()
+	outcome, err := primitives.NewDispatchOutcome(sc.Empty{})
+	assert.Nil(t, err)
+	applyExtrinsicResultOutcome, err := primitives.NewApplyExtrinsicResult(outcome)
+	assert.Nil(t, err)
+	bExtrinsicResult := applyExtrinsicResultOutcome.Bytes()
 
 	mockMemoryUtils.On("GetWasmMemorySlice", dataPtr, dataLen).Return(bUxt)
 	mockRuntimeDecoder.On("DecodeUncheckedExtrinsic", bufferUxt).Return(uxt, nil)
@@ -74,9 +77,13 @@ func Test_Module_ApplyExtrinsic_Fails(t *testing.T) {
 	target := setup()
 
 	bufferUxt := bytes.NewBuffer(bUxt)
-	outcome := primitives.NewDispatchOutcome(sc.Empty{})
-	validityError := primitives.NewTransactionValidityError(primitives.NewInvalidTransactionStale())
-	bExtrinsicResult := primitives.NewApplyExtrinsicResult(validityError).Bytes()
+	outcome, err := primitives.NewDispatchOutcome(sc.Empty{})
+	assert.Nil(t, err)
+	validityError, err := primitives.NewTransactionValidityError(primitives.NewInvalidTransactionStale())
+	assert.Nil(t, err)
+	applyExtrinsicResultValidityErr, err := primitives.NewApplyExtrinsicResult(validityError)
+	assert.Nil(t, err)
+	bExtrinsicResult := applyExtrinsicResultValidityErr.Bytes()
 
 	mockMemoryUtils.On("GetWasmMemorySlice", dataPtr, dataLen).Return(bUxt)
 	mockRuntimeDecoder.On("DecodeUncheckedExtrinsic", bufferUxt).Return(uxt, nil)

--- a/api/core/module.go
+++ b/api/core/module.go
@@ -43,7 +43,7 @@ func (m Module) Name() string {
 }
 
 func (m Module) Item() primitives.ApiItem {
-	hash, err := hashing.MustBlake2b8([]byte(ApiModuleName))
+	hash, err := hashing.Blake2b8([]byte(ApiModuleName))
 	if err != nil {
 		log.Critical(err.Error())
 	}

--- a/api/core/module.go
+++ b/api/core/module.go
@@ -43,10 +43,7 @@ func (m Module) Name() string {
 }
 
 func (m Module) Item() primitives.ApiItem {
-	hash, err := hashing.Blake2b8([]byte(ApiModuleName))
-	if err != nil {
-		log.Critical(err.Error())
-	}
+	hash := hashing.MustBlake2b8([]byte(ApiModuleName))
 	return primitives.NewApiItem(hash, apiVersion)
 }
 

--- a/api/core/module.go
+++ b/api/core/module.go
@@ -43,7 +43,10 @@ func (m Module) Name() string {
 }
 
 func (m Module) Item() primitives.ApiItem {
-	hash := hashing.MustBlake2b8([]byte(ApiModuleName))
+	hash, err := hashing.MustBlake2b8([]byte(ApiModuleName))
+	if err != nil {
+		log.Critical(err.Error())
+	}
 	return primitives.NewApiItem(hash, apiVersion)
 }
 

--- a/api/grandpa/module.go
+++ b/api/grandpa/module.go
@@ -30,10 +30,7 @@ func (m Module) Name() string {
 }
 
 func (m Module) Item() primitives.ApiItem {
-	hash, err := hashing.Blake2b8([]byte(ApiModuleName))
-	if err != nil {
-		log.Critical(err.Error())
-	}
+	hash := hashing.MustBlake2b8([]byte(ApiModuleName))
 	return primitives.NewApiItem(hash, apiVersion)
 }
 

--- a/api/grandpa/module.go
+++ b/api/grandpa/module.go
@@ -30,7 +30,7 @@ func (m Module) Name() string {
 }
 
 func (m Module) Item() primitives.ApiItem {
-	hash, err := hashing.MustBlake2b8([]byte(ApiModuleName))
+	hash, err := hashing.Blake2b8([]byte(ApiModuleName))
 	if err != nil {
 		log.Critical(err.Error())
 	}

--- a/api/grandpa/module.go
+++ b/api/grandpa/module.go
@@ -30,7 +30,10 @@ func (m Module) Name() string {
 }
 
 func (m Module) Item() primitives.ApiItem {
-	hash := hashing.MustBlake2b8([]byte(ApiModuleName))
+	hash, err := hashing.MustBlake2b8([]byte(ApiModuleName))
+	if err != nil {
+		log.Critical(err.Error())
+	}
 	return primitives.NewApiItem(hash, apiVersion)
 }
 

--- a/api/metadata/module.go
+++ b/api/metadata/module.go
@@ -44,10 +44,7 @@ func (m Module) Name() string {
 }
 
 func (m Module) Item() primitives.ApiItem {
-	hash, err := hashing.Blake2b8([]byte(ApiModuleName))
-	if err != nil {
-		log.Critical(err.Error())
-	}
+	hash := hashing.MustBlake2b8([]byte(ApiModuleName))
 	return primitives.NewApiItem(hash, apiVersion)
 }
 

--- a/api/metadata/module.go
+++ b/api/metadata/module.go
@@ -44,7 +44,10 @@ func (m Module) Name() string {
 }
 
 func (m Module) Item() primitives.ApiItem {
-	hash := hashing.MustBlake2b8([]byte(ApiModuleName))
+	hash, err := hashing.MustBlake2b8([]byte(ApiModuleName))
+	if err != nil {
+		log.Critical(err.Error())
+	}
 	return primitives.NewApiItem(hash, apiVersion)
 }
 

--- a/api/metadata/module.go
+++ b/api/metadata/module.go
@@ -44,7 +44,7 @@ func (m Module) Name() string {
 }
 
 func (m Module) Item() primitives.ApiItem {
-	hash, err := hashing.MustBlake2b8([]byte(ApiModuleName))
+	hash, err := hashing.Blake2b8([]byte(ApiModuleName))
 	if err != nil {
 		log.Critical(err.Error())
 	}

--- a/api/offchain_worker/module.go
+++ b/api/offchain_worker/module.go
@@ -33,7 +33,10 @@ func (m Module) Name() string {
 }
 
 func (m Module) Item() types.ApiItem {
-	hash := hashing.MustBlake2b8([]byte(ApiModuleName))
+	hash, err := hashing.MustBlake2b8([]byte(ApiModuleName))
+	if err != nil {
+		log.Critical(err.Error())
+	}
 	return types.NewApiItem(hash, apiVersion)
 }
 

--- a/api/offchain_worker/module.go
+++ b/api/offchain_worker/module.go
@@ -33,10 +33,7 @@ func (m Module) Name() string {
 }
 
 func (m Module) Item() types.ApiItem {
-	hash, err := hashing.Blake2b8([]byte(ApiModuleName))
-	if err != nil {
-		log.Critical(err.Error())
-	}
+	hash := hashing.MustBlake2b8([]byte(ApiModuleName))
 	return types.NewApiItem(hash, apiVersion)
 }
 

--- a/api/offchain_worker/module.go
+++ b/api/offchain_worker/module.go
@@ -33,7 +33,7 @@ func (m Module) Name() string {
 }
 
 func (m Module) Item() types.ApiItem {
-	hash, err := hashing.MustBlake2b8([]byte(ApiModuleName))
+	hash, err := hashing.Blake2b8([]byte(ApiModuleName))
 	if err != nil {
 		log.Critical(err.Error())
 	}

--- a/api/session_keys/module.go
+++ b/api/session_keys/module.go
@@ -35,7 +35,10 @@ func (m Module) Name() string {
 }
 
 func (m Module) Item() types.ApiItem {
-	hash := hashing.MustBlake2b8([]byte(ApiModuleName))
+	hash, err := hashing.MustBlake2b8([]byte(ApiModuleName))
+	if err != nil {
+		log.Critical(err.Error())
+	}
 	return types.NewApiItem(hash, apiVersion)
 }
 

--- a/api/session_keys/module.go
+++ b/api/session_keys/module.go
@@ -35,10 +35,7 @@ func (m Module) Name() string {
 }
 
 func (m Module) Item() types.ApiItem {
-	hash, err := hashing.Blake2b8([]byte(ApiModuleName))
-	if err != nil {
-		log.Critical(err.Error())
-	}
+	hash := hashing.MustBlake2b8([]byte(ApiModuleName))
 	return types.NewApiItem(hash, apiVersion)
 }
 

--- a/api/session_keys/module.go
+++ b/api/session_keys/module.go
@@ -35,7 +35,7 @@ func (m Module) Name() string {
 }
 
 func (m Module) Item() types.ApiItem {
-	hash, err := hashing.MustBlake2b8([]byte(ApiModuleName))
+	hash, err := hashing.Blake2b8([]byte(ApiModuleName))
 	if err != nil {
 		log.Critical(err.Error())
 	}

--- a/api/tagged_transaction_queue/module.go
+++ b/api/tagged_transaction_queue/module.go
@@ -39,7 +39,7 @@ func (m Module) Name() string {
 }
 
 func (m Module) Item() primitives.ApiItem {
-	hash, err := hashing.MustBlake2b8([]byte(ApiModuleName))
+	hash, err := hashing.Blake2b8([]byte(ApiModuleName))
 	if err != nil {
 		log.Critical(err.Error())
 	}

--- a/api/tagged_transaction_queue/module.go
+++ b/api/tagged_transaction_queue/module.go
@@ -39,7 +39,10 @@ func (m Module) Name() string {
 }
 
 func (m Module) Item() primitives.ApiItem {
-	hash := hashing.MustBlake2b8([]byte(ApiModuleName))
+	hash, err := hashing.MustBlake2b8([]byte(ApiModuleName))
+	if err != nil {
+		log.Critical(err.Error())
+	}
 	return primitives.NewApiItem(hash, apiVersion)
 }
 
@@ -71,9 +74,15 @@ func (m Module) ValidateTransaction(dataPtr int32, dataLen int32) int64 {
 
 	var res primitives.TransactionValidityResult
 	if errTx != nil {
-		res = primitives.NewTransactionValidityResult(errTx)
+		res, err = primitives.NewTransactionValidityResult(errTx)
+		if err != nil {
+			log.Critical(err.Error())
+		}
 	} else {
-		res = primitives.NewTransactionValidityResult(ok)
+		res, err = primitives.NewTransactionValidityResult(ok)
+		if err != nil {
+			log.Critical(err.Error())
+		}
 	}
 
 	return m.memUtils.BytesToOffsetAndSize(res.Bytes())

--- a/api/tagged_transaction_queue/module.go
+++ b/api/tagged_transaction_queue/module.go
@@ -39,10 +39,7 @@ func (m Module) Name() string {
 }
 
 func (m Module) Item() primitives.ApiItem {
-	hash, err := hashing.Blake2b8([]byte(ApiModuleName))
-	if err != nil {
-		log.Critical(err.Error())
-	}
+	hash := hashing.MustBlake2b8([]byte(ApiModuleName))
 	return primitives.NewApiItem(hash, apiVersion)
 }
 

--- a/api/tagged_transaction_queue/module_test.go
+++ b/api/tagged_transaction_queue/module_test.go
@@ -22,10 +22,10 @@ var (
 			common.MustHexToHash("0x88dc3417d5058ec4b4503e0c12ea1a0a89be200fe98922423d4334014fa6b0ff").ToBytes(),
 		)}
 
-	validTx               = primitives.DefaultValidTransaction()
-	txValidityError       = primitives.NewTransactionValidityError(primitives.NewInvalidTransactionStale())
-	validitySuccessResult = primitives.NewTransactionValidityResult(validTx)
-	validityFailResult    = primitives.NewTransactionValidityResult(txValidityError)
+	validTx                  = primitives.DefaultValidTransaction()
+	txValidityError, _       = primitives.NewTransactionValidityError(primitives.NewInvalidTransactionStale())
+	validitySuccessResult, _ = primitives.NewTransactionValidityResult(validTx)
+	validityFailResult, _    = primitives.NewTransactionValidityResult(txValidityError)
 )
 
 var (

--- a/api/transaction_payment/module.go
+++ b/api/transaction_payment/module.go
@@ -38,7 +38,10 @@ func (m Module) Name() string {
 }
 
 func (m Module) Item() primitives.ApiItem {
-	hash := hashing.MustBlake2b8([]byte(ApiModuleName))
+	hash, err := hashing.MustBlake2b8([]byte(ApiModuleName))
+	if err != nil {
+		log.Critical(err.Error())
+	}
 	return primitives.NewApiItem(hash, apiVersion)
 }
 

--- a/api/transaction_payment/module.go
+++ b/api/transaction_payment/module.go
@@ -38,10 +38,7 @@ func (m Module) Name() string {
 }
 
 func (m Module) Item() primitives.ApiItem {
-	hash, err := hashing.Blake2b8([]byte(ApiModuleName))
-	if err != nil {
-		log.Critical(err.Error())
-	}
+	hash := hashing.MustBlake2b8([]byte(ApiModuleName))
 	return primitives.NewApiItem(hash, apiVersion)
 }
 

--- a/api/transaction_payment/module.go
+++ b/api/transaction_payment/module.go
@@ -38,7 +38,7 @@ func (m Module) Name() string {
 }
 
 func (m Module) Item() primitives.ApiItem {
-	hash, err := hashing.MustBlake2b8([]byte(ApiModuleName))
+	hash, err := hashing.Blake2b8([]byte(ApiModuleName))
 	if err != nil {
 		log.Critical(err.Error())
 	}

--- a/api/transaction_payment_call/module.go
+++ b/api/transaction_payment_call/module.go
@@ -37,7 +37,10 @@ func (m Module) Name() string {
 }
 
 func (m Module) Item() primitives.ApiItem {
-	hash := hashing.MustBlake2b8([]byte(ApiModuleName))
+	hash, err := hashing.MustBlake2b8([]byte(ApiModuleName))
+	if err != nil {
+		log.Critical(err.Error())
+	}
 	return primitives.NewApiItem(hash, apiVersion)
 }
 

--- a/api/transaction_payment_call/module.go
+++ b/api/transaction_payment_call/module.go
@@ -37,10 +37,7 @@ func (m Module) Name() string {
 }
 
 func (m Module) Item() primitives.ApiItem {
-	hash, err := hashing.Blake2b8([]byte(ApiModuleName))
-	if err != nil {
-		log.Critical(err.Error())
-	}
+	hash := hashing.MustBlake2b8([]byte(ApiModuleName))
 	return primitives.NewApiItem(hash, apiVersion)
 }
 

--- a/api/transaction_payment_call/module.go
+++ b/api/transaction_payment_call/module.go
@@ -37,7 +37,7 @@ func (m Module) Name() string {
 }
 
 func (m Module) Item() primitives.ApiItem {
-	hash, err := hashing.MustBlake2b8([]byte(ApiModuleName))
+	hash, err := hashing.Blake2b8([]byte(ApiModuleName))
 	if err != nil {
 		log.Critical(err.Error())
 	}

--- a/constants/address.go
+++ b/constants/address.go
@@ -3,7 +3,7 @@ package constants
 import primitives "github.com/LimeChain/gosemble/primitives/types"
 
 var (
-	ZeroAddress = primitives.NewAddress32(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
-	OneAddress  = primitives.NewAddress32(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1)
-	TwoAddress  = primitives.NewAddress32(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2)
+	ZeroAddress, _ = primitives.NewAddress32(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+	OneAddress, _  = primitives.NewAddress32(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1)
+	TwoAddress, _  = primitives.NewAddress32(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2)
 )

--- a/execution/extrinsic/runtime_extrinsic.go
+++ b/execution/extrinsic/runtime_extrinsic.go
@@ -34,8 +34,12 @@ func New(modules []primitives.Module, extra primitives.SignedExtra) RuntimeExtri
 	}
 }
 
-func (re runtimeExtrinsic) Module(index sc.U8) (module primitives.Module, isFound bool) {
-	return primitives.GetModule(index, re.modules)
+func (re runtimeExtrinsic) Module(index sc.U8) (primitives.Module, bool) {
+	mod, err := primitives.GetModule(index, re.modules)
+	if err != nil {
+		return nil, false
+	}
+	return mod, true
 }
 
 func (re runtimeExtrinsic) CreateInherents(inherentData primitives.InherentData) ([]byte, error) {

--- a/execution/extrinsic/unsigned_validator.go
+++ b/execution/extrinsic/unsigned_validator.go
@@ -2,6 +2,7 @@ package extrinsic
 
 import (
 	sc "github.com/LimeChain/goscale"
+	"github.com/LimeChain/gosemble/primitives/log"
 	primitives "github.com/LimeChain/gosemble/primitives/types"
 )
 
@@ -31,7 +32,11 @@ func (v UnsignedValidatorForChecked) PreDispatch(call primitives.Call) (sc.Empty
 func (v UnsignedValidatorForChecked) ValidateUnsigned(txSource primitives.TransactionSource, call primitives.Call) (primitives.ValidTransaction, primitives.TransactionValidityError) {
 	module, ok := v.runtimeExtrinsic.Module(call.ModuleIndex())
 	if !ok {
-		return primitives.ValidTransaction{}, primitives.NewTransactionValidityError(primitives.NewUnknownTransactionNoUnsignedValidator())
+		unknownTransactionNoUnsignedValidator, err := primitives.NewTransactionValidityError(primitives.NewUnknownTransactionNoUnsignedValidator())
+		if err != nil {
+			log.Critical(err.Error())
+		}
+		return primitives.ValidTransaction{}, unknownTransactionNoUnsignedValidator
 	}
 
 	return module.ValidateUnsigned(txSource, call)

--- a/execution/types/checked_extrinsic.go
+++ b/execution/types/checked_extrinsic.go
@@ -3,6 +3,7 @@ package types
 import (
 	sc "github.com/LimeChain/goscale"
 	"github.com/LimeChain/gosemble/frame/support"
+	"github.com/LimeChain/gosemble/primitives/log"
 	primitives "github.com/LimeChain/gosemble/primitives/types"
 )
 
@@ -94,7 +95,10 @@ func (c checkedExtrinsic) Apply(validator primitives.UnsignedValidator, info *pr
 		postInfo = resWithInfo.Ok
 	}
 
-	dispatchResult := primitives.NewDispatchResult(resWithInfo.Err)
+	dispatchResult, dispatchResultErr := primitives.NewDispatchResult(resWithInfo.Err)
+	if dispatchResultErr != nil {
+		log.Critical(dispatchResultErr.Error())
+	}
 
 	return resWithInfo, c.extra.PostDispatch(maybePre, info, &postInfo, length, &dispatchResult)
 }

--- a/execution/types/runtime_decoder.go
+++ b/execution/types/runtime_decoder.go
@@ -104,11 +104,9 @@ func (rd runtimeDecoder) DecodeCall(buffer *bytes.Buffer) (primitives.Call, erro
 		return nil, err
 	}
 
-	module, ok := primitives.GetModule(moduleIndex, rd.modules)
-	if !ok {
-		// TODO: there is an issue with fmt.Sprintf when compiled with the "custom gc"
-		// log.Critical(fmt.Sprintf("module with index [%d] not found", moduleIndex))
-		log.Critical("module with index [" + strconv.Itoa(int(moduleIndex)) + "] not found")
+	module, err := primitives.GetModule(moduleIndex, rd.modules)
+	if err != nil {
+		return nil, err
 	}
 
 	function, ok := module.Functions()[functionIndex]

--- a/execution/types/runtime_decoder_test.go
+++ b/execution/types/runtime_decoder_test.go
@@ -277,12 +277,13 @@ func Test_RuntimeDecoder_DecodeCall_Module_Not_Exists(t *testing.T) {
 	}
 
 	buf := bytes.NewBuffer(callBytes)
-
 	mockModuleOne.On("GetIndex").Return(moduleOneIdx)
 
-	assert.PanicsWithValue(t, "module with index ["+strconv.Itoa(int(idxModuleNotExists))+"] not found", func() {
-		target.DecodeCall(buf)
-	})
+	mod, err := target.DecodeCall(buf)
+
+	assert.Error(t, err)
+	assert.Equal(t, err.Error(), "module with index ["+strconv.Itoa(int(idxModuleNotExists))+"] not found.")
+	assert.Nil(t, mod)
 }
 
 func Test_RuntimeDecoder_DecodeCall_Function_Not_Exists(t *testing.T) {

--- a/execution/types/unchecked_extrinsic_test.go
+++ b/execution/types/unchecked_extrinsic_test.go
@@ -17,21 +17,21 @@ const (
 )
 
 var (
-	unknownTransactionCannotLookupError = types.NewTransactionValidityError(
+	unknownTransactionCannotLookupError, _ = types.NewTransactionValidityError(
 		types.NewUnknownTransactionCannotLookup(),
 	)
-	invalidTransactionAncientBirthBlockError = types.NewTransactionValidityError(
+	invalidTransactionAncientBirthBlockError, _ = types.NewTransactionValidityError(
 		types.NewInvalidTransactionAncientBirthBlock(),
 	)
-	invalidTransactionBadProofError = types.NewTransactionValidityError(
+	invalidTransactionBadProofError, _ = types.NewTransactionValidityError(
 		types.NewInvalidTransactionBadProof(),
 	)
 
 	signerAddressBytes = []byte{
 		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	}
-	signerAddress = types.NewAddress32(sc.BytesToSequenceU8(signerAddressBytes)...)
-	signer        = types.NewMultiAddressId(types.AccountId{Address32: signerAddress})
+	signerAddress, _ = types.NewAddress32(sc.BytesToSequenceU8(signerAddressBytes)...)
+	signer           = types.NewMultiAddressId(types.AccountId{Address32: signerAddress})
 
 	signatureBytes = []byte{
 		1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,

--- a/frame/aura/module.go
+++ b/frame/aura/module.go
@@ -69,7 +69,9 @@ func (m Module) PreDispatch(_ primitives.Call) (sc.Empty, primitives.Transaction
 }
 
 func (m Module) ValidateUnsigned(_ primitives.TransactionSource, _ primitives.Call) (primitives.ValidTransaction, primitives.TransactionValidityError) {
-	return primitives.ValidTransaction{}, primitives.NewTransactionValidityError(primitives.NewUnknownTransactionNoUnsignedValidator())
+	// TODO https://github.com/LimeChain/gosemble/issues/271
+	unknownTransactionNoUnsignedValidator, _ := primitives.NewTransactionValidityError(primitives.NewUnknownTransactionNoUnsignedValidator())
+	return primitives.ValidTransaction{}, unknownTransactionNoUnsignedValidator
 }
 
 func (m Module) KeyType() primitives.PublicKeyType {

--- a/frame/aura/module_test.go
+++ b/frame/aura/module_test.go
@@ -22,6 +22,10 @@ const (
 )
 
 var (
+	unknownTransactionNoUnsignedValidator, _ = types.NewTransactionValidityError(types.NewUnknownTransactionNoUnsignedValidator())
+)
+
+var (
 	dbWeight = types.RuntimeDbWeight{
 		Read:  3 * weightRefTimePerNanos,
 		Write: 7 * weightRefTimePerNanos,
@@ -183,7 +187,7 @@ func Test_Module_ValidateUnsigned(t *testing.T) {
 
 	result, err := module.ValidateUnsigned(types.NewTransactionSourceLocal(), new(mocks.Call))
 
-	assert.Equal(t, types.NewTransactionValidityError(types.NewUnknownTransactionNoUnsignedValidator()), err)
+	assert.Equal(t, unknownTransactionNoUnsignedValidator, err)
 	assert.Equal(t, types.ValidTransaction{}, result)
 }
 

--- a/frame/balances/call_force_free_test.go
+++ b/frame/balances/call_force_free_test.go
@@ -17,6 +17,8 @@ const (
 )
 
 var (
+	targetAddress32, _ = targetAddress.AsAddress32()
+
 	accountInfo = primitives.AccountInfo{
 		Data: primitives.AccountData{
 			Free:       sc.NewU128(4),
@@ -139,11 +141,11 @@ func Test_Call_ForceFree_Dispatch_Success(t *testing.T) {
 	target := setupCallForceFree()
 	actual := sc.NewU128(1)
 	mutateResult := sc.Result[sc.Encodable]{HasError: false, Value: actual}
-	event := newEventUnreserved(moduleId, targetAddress.AsAddress32().FixedSequence, actual)
+	event := newEventUnreserved(moduleId, targetAddress32.FixedSequence, actual)
 
-	mockStoredMap.On("Get", targetAddress.AsAddress32().FixedSequence).Return(accountInfo, nil)
+	mockStoredMap.On("Get", targetAddress32.FixedSequence).Return(accountInfo, nil)
 	mockMutator.On("tryMutateAccount",
-		targetAddress.AsAddress32(),
+		targetAddress32,
 		mockTypeMutateAccountDataBool).
 		Return(mutateResult)
 	mockStoredMap.On("DepositEvent", event)
@@ -151,10 +153,10 @@ func Test_Call_ForceFree_Dispatch_Success(t *testing.T) {
 	result := target.Dispatch(primitives.NewRawOriginRoot(), sc.NewVaryingData(targetAddress, targetValue))
 
 	assert.Equal(t, primitives.DispatchResultWithPostInfo[primitives.PostDispatchInfo]{}, result)
-	mockStoredMap.AssertCalled(t, "Get", targetAddress.AsAddress32().FixedSequence)
+	mockStoredMap.AssertCalled(t, "Get", targetAddress32.FixedSequence)
 	mockMutator.AssertCalled(t,
 		"tryMutateAccount",
-		targetAddress.AsAddress32(),
+		targetAddress32,
 		mockTypeMutateAccountDataBool,
 	)
 	mockStoredMap.AssertCalled(t, "DepositEvent", event)
@@ -189,7 +191,7 @@ func Test_Call_ForceFree_Dispatch_InvalidLookup(t *testing.T) {
 	result := target.Dispatch(primitives.NewRawOriginRoot(), sc.NewVaryingData(primitives.NewMultiAddress20(primitives.Address20{}), targetValue))
 
 	assert.Equal(t, expected, result)
-	mockStoredMap.AssertNotCalled(t, "Get", targetAddress.AsAddress32().FixedSequence)
+	mockStoredMap.AssertNotCalled(t, "Get", targetAddress32.FixedSequence)
 	mockMutator.AssertNotCalled(t, "tryMutateAccount", mock.Anything, mock.Anything)
 	mockStoredMap.AssertNotCalled(t, "DepositEvent", mock.Anything)
 }
@@ -200,7 +202,7 @@ func Test_Call_ForceFree_Dispatch_ZeroBalance(t *testing.T) {
 	result := target.Dispatch(primitives.NewRawOriginRoot(), sc.NewVaryingData(targetAddress, constants.Zero))
 
 	assert.Equal(t, primitives.DispatchResultWithPostInfo[primitives.PostDispatchInfo]{}, result)
-	mockStoredMap.AssertNotCalled(t, "Get", targetAddress.AsAddress32().FixedSequence)
+	mockStoredMap.AssertNotCalled(t, "Get", targetAddress32.FixedSequence)
 	mockMutator.AssertNotCalled(t, "tryMutateAccount", mock.Anything, mock.Anything)
 	mockStoredMap.AssertNotCalled(t, "DepositEvent", mock.Anything)
 }
@@ -209,12 +211,12 @@ func Test_Call_ForceFree_Dispatch_ZeroTotalStorageBalance(t *testing.T) {
 	target := setupCallForceFree()
 	accountInfo := primitives.AccountInfo{Data: primitives.AccountData{}}
 
-	mockStoredMap.On("Get", targetAddress.AsAddress32().FixedSequence).Return(accountInfo, nil)
+	mockStoredMap.On("Get", targetAddress32.FixedSequence).Return(accountInfo, nil)
 
 	result := target.Dispatch(primitives.NewRawOriginRoot(), sc.NewVaryingData(targetAddress, targetValue))
 
 	assert.Equal(t, primitives.DispatchResultWithPostInfo[primitives.PostDispatchInfo]{}, result)
-	mockStoredMap.AssertCalled(t, "Get", targetAddress.AsAddress32().FixedSequence)
+	mockStoredMap.AssertCalled(t, "Get", targetAddress32.FixedSequence)
 	mockMutator.AssertNotCalled(t, "tryMutateAccount", mock.Anything, mock.Anything)
 	mockStoredMap.AssertNotCalled(t, "DepositEvent", mock.Anything)
 }
@@ -223,19 +225,19 @@ func Test_Call_ForceFree_Dispatch_Mutation_Fails(t *testing.T) {
 	target := setupCallForceFree()
 	mutateResult := sc.Result[sc.Encodable]{HasError: true}
 
-	mockStoredMap.On("Get", targetAddress.AsAddress32().FixedSequence).Return(accountInfo, nil)
+	mockStoredMap.On("Get", targetAddress32.FixedSequence).Return(accountInfo, nil)
 	mockMutator.On("tryMutateAccount",
-		targetAddress.AsAddress32(),
+		targetAddress32,
 		mockTypeMutateAccountDataBool,
 	).Return(mutateResult)
 
 	result := target.Dispatch(primitives.NewRawOriginRoot(), sc.NewVaryingData(targetAddress, targetValue))
 
 	assert.Equal(t, primitives.DispatchResultWithPostInfo[primitives.PostDispatchInfo]{}, result)
-	mockStoredMap.AssertCalled(t, "Get", targetAddress.AsAddress32().FixedSequence)
+	mockStoredMap.AssertCalled(t, "Get", targetAddress32.FixedSequence)
 	mockMutator.AssertCalled(t,
 		"tryMutateAccount",
-		targetAddress.AsAddress32(),
+		targetAddress32,
 		mockTypeMutateAccountDataBool,
 	)
 	mockStoredMap.AssertNotCalled(t, "DepositEvent", mock.Anything)

--- a/frame/balances/call_force_transfer_test.go
+++ b/frame/balances/call_force_transfer_test.go
@@ -105,13 +105,13 @@ func Test_Call_ForceTransfer_Dispatch_Success(t *testing.T) {
 
 	mockMutator.On(
 		"tryMutateAccountWithDust",
-		toAddress.AsAddress32(),
+		toAddress32,
 		mockTypeMutateAccountDataBool,
 	).
 		Return(sc.Result[sc.Encodable]{})
 	mockStoredMap.On(
 		"DepositEvent",
-		newEventTransfer(moduleId, fromAddress.AsAddress32().FixedSequence, toAddress.AsAddress32().FixedSequence, targetValue),
+		newEventTransfer(moduleId, fromAddress32.FixedSequence, toAddress32.FixedSequence, targetValue),
 	).
 		Return()
 
@@ -120,12 +120,12 @@ func Test_Call_ForceTransfer_Dispatch_Success(t *testing.T) {
 	assert.Equal(t, expect, result)
 	mockMutator.AssertCalled(t,
 		"tryMutateAccountWithDust",
-		toAddress.AsAddress32(),
+		toAddress32,
 		mockTypeMutateAccountDataBool,
 	)
 	mockStoredMap.AssertCalled(t,
 		"DepositEvent",
-		newEventTransfer(moduleId, fromAddress.AsAddress32().FixedSequence, toAddress.AsAddress32().FixedSequence, targetValue),
+		newEventTransfer(moduleId, fromAddress32.FixedSequence, toAddress32.FixedSequence, targetValue),
 	)
 }
 

--- a/frame/balances/call_set_balance.go
+++ b/frame/balances/call_set_balance.go
@@ -5,6 +5,7 @@ import (
 
 	sc "github.com/LimeChain/goscale"
 	"github.com/LimeChain/gosemble/frame/support"
+	"github.com/LimeChain/gosemble/primitives/log"
 	"github.com/LimeChain/gosemble/primitives/types"
 )
 
@@ -174,10 +175,15 @@ func (c callSetBalance) setBalance(origin types.RawOrigin, who types.MultiAddres
 			Drop()
 	}
 
+	address32, addressErr := who.AsAddress32()
+	if addressErr != nil {
+		log.Critical(addressErr.Error())
+	}
+
 	c.storedMap.DepositEvent(
 		newEventBalanceSet(
 			c.ModuleId,
-			who.AsAddress32().FixedSequence,
+			address32.FixedSequence,
 			newFree,
 			newReserved,
 		),

--- a/frame/balances/call_set_balance_test.go
+++ b/frame/balances/call_set_balance_test.go
@@ -121,11 +121,11 @@ func Test_Call_SetBalance_Dispatch_Success(t *testing.T) {
 
 	mockMutator.On(
 		"tryMutateAccount",
-		targetAddress.AsAddress32(),
+		targetAddress32,
 		mockTypeMutateAccountDataBool,
 	).
 		Return(mockResult)
-	mockStoredMap.On("DepositEvent", newEventBalanceSet(moduleId, targetAddress.AsAddress32().FixedSequence, newFree, newReserved))
+	mockStoredMap.On("DepositEvent", newEventBalanceSet(moduleId, targetAddress32.FixedSequence, newFree, newReserved))
 
 	result := target.Dispatch(primitives.NewRawOriginRoot(), sc.NewVaryingData(targetAddress, sc.ToCompact(newFree), sc.ToCompact(newReserved)))
 
@@ -134,12 +134,12 @@ func Test_Call_SetBalance_Dispatch_Success(t *testing.T) {
 	mockStorageTotalIssuance.AssertNotCalled(t, "Put", mock.Anything)
 	mockMutator.AssertCalled(t,
 		"tryMutateAccount",
-		targetAddress.AsAddress32(),
+		targetAddress32,
 		mockTypeMutateAccountDataBool,
 	)
 	mockStoredMap.AssertCalled(t,
 		"DepositEvent",
-		newEventBalanceSet(moduleId, targetAddress.AsAddress32().FixedSequence, newFree, newReserved),
+		newEventBalanceSet(moduleId, targetAddress32.FixedSequence, newFree, newReserved),
 	)
 }
 
@@ -191,7 +191,7 @@ func Test_Call_SetBalance_setBalance_Success(t *testing.T) {
 
 	mockMutator.On(
 		"tryMutateAccount",
-		targetAddress.AsAddress32(),
+		targetAddress32,
 		mockTypeMutateAccountDataBool,
 	).Return(mockResult)
 	mockStorageTotalIssuance.On("Get").Return(sc.NewU128(1)) // positive imbalance
@@ -201,14 +201,14 @@ func Test_Call_SetBalance_setBalance_Success(t *testing.T) {
 		Return().Once() // newReserved positive imbalance
 	mockStoredMap.On(
 		"DepositEvent",
-		newEventBalanceSet(moduleId, targetAddress.AsAddress32().FixedSequence, newFree, newReserved))
+		newEventBalanceSet(moduleId, targetAddress32.FixedSequence, newFree, newReserved))
 
 	result := target.setBalance(primitives.NewRawOriginRoot(), targetAddress, newFree, newReserved)
 
 	assert.Equal(t, sc.VaryingData(nil), result)
 	mockMutator.AssertCalled(t,
 		"tryMutateAccount",
-		targetAddress.AsAddress32(),
+		targetAddress32,
 		mockTypeMutateAccountDataBool,
 	)
 	mockStorageTotalIssuance.AssertNumberOfCalls(t, "Get", 2)
@@ -217,7 +217,7 @@ func Test_Call_SetBalance_setBalance_Success(t *testing.T) {
 	mockStorageTotalIssuance.AssertCalled(t, "Put", newReserved.Sub(oldReserved).Add(sc.NewU128(1)))
 	mockStoredMap.AssertCalled(t,
 		"DepositEvent",
-		newEventBalanceSet(moduleId, targetAddress.AsAddress32().FixedSequence, newFree, newReserved),
+		newEventBalanceSet(moduleId, targetAddress32.FixedSequence, newFree, newReserved),
 	)
 }
 
@@ -231,12 +231,12 @@ func Test_Call_SetBalance_setBalance_Success_LessThanExistentialDeposit(t *testi
 
 	mockMutator.On(
 		"tryMutateAccount",
-		targetAddress.AsAddress32(),
+		targetAddress32,
 		mockTypeMutateAccountDataBool,
 	).Return(mockResult)
 	mockStoredMap.On(
 		"DepositEvent",
-		newEventBalanceSet(moduleId, targetAddress.AsAddress32().FixedSequence, newFree, newReserved))
+		newEventBalanceSet(moduleId, targetAddress32.FixedSequence, newFree, newReserved))
 
 	result := target.setBalance(primitives.NewRawOriginRoot(), targetAddress, newFree, newReserved)
 
@@ -245,12 +245,12 @@ func Test_Call_SetBalance_setBalance_Success_LessThanExistentialDeposit(t *testi
 	mockStorageTotalIssuance.AssertNotCalled(t, "Put", mock.Anything)
 	mockMutator.AssertCalled(t,
 		"tryMutateAccount",
-		targetAddress.AsAddress32(),
+		targetAddress32,
 		mockTypeMutateAccountDataBool,
 	)
 	mockStoredMap.AssertCalled(t,
 		"DepositEvent",
-		newEventBalanceSet(moduleId, targetAddress.AsAddress32().FixedSequence, newFree, newReserved),
+		newEventBalanceSet(moduleId, targetAddress32.FixedSequence, newFree, newReserved),
 	)
 }
 
@@ -263,21 +263,21 @@ func Test_Call_SetBalance_setBalance_Success_NegativeImbalance(t *testing.T) {
 	}
 
 	mockMutator.On("tryMutateAccount",
-		targetAddress.AsAddress32(),
+		targetAddress32,
 		mockTypeMutateAccountDataBool,
 	).Return(mockResult)
 	mockStorageTotalIssuance.On("Get").Return(oldReserved.Add(oldFree)).Once() // newFree negative imbalance
 	mockStorageTotalIssuance.On("Put", oldFree).Return().Once()                // newFree negative imbalance
 	mockStorageTotalIssuance.On("Get").Return(sc.NewU128(4)).Once()            // newReserved negative imbalance
 	mockStorageTotalIssuance.On("Put", sc.NewU128(2)).Return().Once()          // newReserved negative imbalance
-	mockStoredMap.On("DepositEvent", newEventBalanceSet(moduleId, targetAddress.AsAddress32().FixedSequence, newFree, newReserved))
+	mockStoredMap.On("DepositEvent", newEventBalanceSet(moduleId, targetAddress32.FixedSequence, newFree, newReserved))
 
 	result := target.setBalance(primitives.NewRawOriginRoot(), targetAddress, newFree, newReserved)
 
 	assert.Equal(t, sc.VaryingData(nil), result)
 	mockMutator.AssertCalled(t,
 		"tryMutateAccount",
-		targetAddress.AsAddress32(),
+		targetAddress32,
 		mockTypeMutateAccountDataBool,
 	)
 	mockStorageTotalIssuance.AssertNumberOfCalls(t, "Get", 2)
@@ -286,7 +286,7 @@ func Test_Call_SetBalance_setBalance_Success_NegativeImbalance(t *testing.T) {
 	mockStorageTotalIssuance.AssertCalled(t, "Put", sc.NewU128(2))
 	mockStoredMap.AssertCalled(t,
 		"DepositEvent",
-		newEventBalanceSet(moduleId, targetAddress.AsAddress32().FixedSequence, newFree, newReserved),
+		newEventBalanceSet(moduleId, targetAddress32.FixedSequence, newFree, newReserved),
 	)
 }
 
@@ -324,7 +324,7 @@ func Test_Call_SetBalance_setBalance_tryMutateAccount_Fails(t *testing.T) {
 	}
 	mockMutator.On(
 		"tryMutateAccount",
-		targetAddress.AsAddress32(),
+		targetAddress32,
 		mockTypeMutateAccountDataBool,
 	).Return(mockResult)
 
@@ -333,7 +333,7 @@ func Test_Call_SetBalance_setBalance_tryMutateAccount_Fails(t *testing.T) {
 	assert.Equal(t, err, result)
 	mockMutator.AssertCalled(t,
 		"tryMutateAccount",
-		targetAddress.AsAddress32(),
+		targetAddress32,
 		mockTypeMutateAccountDataBool,
 	)
 	mockStorageTotalIssuance.AssertNotCalled(t, "Get")

--- a/frame/balances/call_transfer.go
+++ b/frame/balances/call_transfer.go
@@ -6,6 +6,7 @@ import (
 
 	sc "github.com/LimeChain/goscale"
 	"github.com/LimeChain/gosemble/constants"
+	"github.com/LimeChain/gosemble/primitives/log"
 	"github.com/LimeChain/gosemble/primitives/types"
 	primitives "github.com/LimeChain/gosemble/primitives/types"
 )
@@ -138,7 +139,10 @@ func (t transfer) transfer(origin types.RawOrigin, dest types.MultiAddress, valu
 		return types.NewDispatchErrorCannotLookup()
 	}
 
-	transactor := origin.AsSigned()
+	transactor, originErr := origin.AsSigned()
+	if err != nil {
+		log.Critical(originErr.Error())
+	}
 
 	return t.trans(transactor, to, value, types.ExistenceRequirementAllowDeath)
 }

--- a/frame/balances/call_transfer_all.go
+++ b/frame/balances/call_transfer_all.go
@@ -116,7 +116,11 @@ func (c callTransferAll) transferAll(origin types.RawOrigin, dest types.MultiAdd
 		return types.NewDispatchErrorBadOrigin()
 	}
 
-	transactor := origin.AsSigned()
+	transactor, err := origin.AsSigned()
+	if err != nil {
+		log.Critical(err.Error())
+	}
+
 	reducibleBalance, err := c.reducibleBalance(transactor, keepAlive)
 	if err != nil {
 		return primitives.NewDispatchErrorOther(sc.Str(err.Error()))

--- a/frame/balances/call_transfer_all_test.go
+++ b/frame/balances/call_transfer_all_test.go
@@ -100,43 +100,43 @@ func Test_Call_TransferAll_Dispatch_Success(t *testing.T) {
 		Ok:       primitives.PostDispatchInfo{},
 	}
 
-	mockStoredMap.On("Get", fromAddress.AsAddress32().FixedSequence).Return(accountInfo, nil)
-	mockStoredMap.On("CanDecProviders", fromAddress.AsAddress32()).Return(true, nil)
+	mockStoredMap.On("Get", fromAddress32.FixedSequence).Return(accountInfo, nil)
+	mockStoredMap.On("CanDecProviders", fromAddress32).Return(true, nil)
 	mockMutator.On("tryMutateAccountWithDust",
-		toAddress.AsAddress32(),
+		toAddress32,
 		mockTypeMutateAccountDataBool,
 	).Return(sc.Result[sc.Encodable]{})
 	mockStoredMap.On(
 		"DepositEvent",
 		newEventTransfer(
 			moduleId,
-			fromAddress.AsAddress32().
+			fromAddress32.
 				FixedSequence,
-			toAddress.AsAddress32().FixedSequence,
+			toAddress32.FixedSequence,
 			accountInfo.Data.Free.Sub(sc.NewU128(1)),
 		),
 	).
 		Return()
 
 	result := target.Dispatch(
-		primitives.NewRawOriginSigned(fromAddress.AsAddress32()),
+		primitives.NewRawOriginSigned(fromAddress32),
 		sc.NewVaryingData(toAddress, sc.Bool(true)),
 	)
 
 	assert.Equal(t, expect, result)
-	mockStoredMap.AssertCalled(t, "Get", fromAddress.AsAddress32().FixedSequence)
-	mockStoredMap.AssertCalled(t, "CanDecProviders", fromAddress.AsAddress32())
+	mockStoredMap.AssertCalled(t, "Get", fromAddress32.FixedSequence)
+	mockStoredMap.AssertCalled(t, "CanDecProviders", fromAddress32)
 	mockMutator.AssertCalled(t,
 		"tryMutateAccountWithDust",
-		toAddress.AsAddress32(),
+		toAddress32,
 		mockTypeMutateAccountDataBool,
 	)
 	mockStoredMap.AssertCalled(t,
 		"DepositEvent",
 		newEventTransfer(
 			moduleId,
-			fromAddress.AsAddress32().FixedSequence,
-			toAddress.AsAddress32().FixedSequence,
+			fromAddress32.FixedSequence,
+			toAddress32.FixedSequence,
 			accountInfo.Data.Free.Sub(sc.NewU128(1)),
 		),
 	)
@@ -171,17 +171,17 @@ func Test_Call_TransferAll_Dispatch_CannotLookup(t *testing.T) {
 			Error: primitives.NewDispatchErrorCannotLookup(),
 		},
 	}
-	mockStoredMap.On("Get", fromAddress.AsAddress32().FixedSequence).Return(accountInfo, nil)
-	mockStoredMap.On("CanDecProviders", fromAddress.AsAddress32()).Return(true, nil)
+	mockStoredMap.On("Get", fromAddress32.FixedSequence).Return(accountInfo, nil)
+	mockStoredMap.On("CanDecProviders", fromAddress32).Return(true, nil)
 
 	result := target.Dispatch(
-		primitives.NewRawOriginSigned(fromAddress.AsAddress32()),
+		primitives.NewRawOriginSigned(fromAddress32),
 		sc.NewVaryingData(primitives.NewMultiAddress20(primitives.Address20{}), sc.Bool(true)),
 	)
 
 	assert.Equal(t, expect, result)
-	mockStoredMap.AssertCalled(t, "Get", fromAddress.AsAddress32().FixedSequence)
-	mockStoredMap.AssertCalled(t, "CanDecProviders", fromAddress.AsAddress32())
+	mockStoredMap.AssertCalled(t, "Get", fromAddress32.FixedSequence)
+	mockStoredMap.AssertCalled(t, "CanDecProviders", fromAddress32)
 	mockMutator.AssertNotCalled(t, "tryMutateAccountWithDust", mock.Anything, mock.Anything)
 	mockStoredMap.AssertNotCalled(t, "DepositEvent", mock.Anything)
 }
@@ -193,41 +193,41 @@ func Test_Call_TransferAll_Dispatch_AllowDeath(t *testing.T) {
 		Ok:       primitives.PostDispatchInfo{},
 	}
 
-	mockStoredMap.On("Get", fromAddress.AsAddress32().FixedSequence).Return(accountInfo, nil)
-	mockStoredMap.On("CanDecProviders", fromAddress.AsAddress32()).Return(true, nil)
+	mockStoredMap.On("Get", fromAddress32.FixedSequence).Return(accountInfo, nil)
+	mockStoredMap.On("CanDecProviders", fromAddress32).Return(true, nil)
 	mockMutator.On(
 		"tryMutateAccountWithDust",
-		toAddress.AsAddress32(),
+		toAddress32,
 		mockTypeMutateAccountDataBool,
 	).Return(sc.Result[sc.Encodable]{})
 	mockStoredMap.On(
 		"DepositEvent",
 		newEventTransfer(
 			moduleId,
-			fromAddress.AsAddress32().FixedSequence,
-			toAddress.AsAddress32().FixedSequence,
+			fromAddress32.FixedSequence,
+			toAddress32.FixedSequence,
 			accountInfo.Data.Free,
 		),
 	).Return()
 
 	result := target.Dispatch(
-		primitives.NewRawOriginSigned(fromAddress.AsAddress32()),
+		primitives.NewRawOriginSigned(fromAddress32),
 		sc.NewVaryingData(toAddress, sc.Bool(false)))
 
 	assert.Equal(t, expect, result)
-	mockStoredMap.AssertCalled(t, "Get", fromAddress.AsAddress32().FixedSequence)
-	mockStoredMap.AssertCalled(t, "CanDecProviders", fromAddress.AsAddress32())
+	mockStoredMap.AssertCalled(t, "Get", fromAddress32.FixedSequence)
+	mockStoredMap.AssertCalled(t, "CanDecProviders", fromAddress32)
 	mockMutator.AssertCalled(t,
 		"tryMutateAccountWithDust",
-		toAddress.AsAddress32(),
+		toAddress32,
 		mockTypeMutateAccountDataBool,
 	)
 	mockStoredMap.AssertCalled(t,
 		"DepositEvent",
 		newEventTransfer(
 			moduleId,
-			fromAddress.AsAddress32().FixedSequence,
-			toAddress.AsAddress32().FixedSequence,
+			fromAddress32.FixedSequence,
+			toAddress32.FixedSequence,
 			accountInfo.Data.Free,
 		),
 	)

--- a/frame/balances/call_transfer_keep_alive.go
+++ b/frame/balances/call_transfer_keep_alive.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 
 	sc "github.com/LimeChain/goscale"
+	"github.com/LimeChain/gosemble/primitives/log"
 	"github.com/LimeChain/gosemble/primitives/types"
 	primitives "github.com/LimeChain/gosemble/primitives/types"
 )
@@ -111,7 +112,10 @@ func (c callTransferKeepAlive) transferKeepAlive(origin types.RawOrigin, dest ty
 	if !origin.IsSignedOrigin() {
 		return types.NewDispatchErrorBadOrigin()
 	}
-	transactor := origin.AsSigned()
+	transactor, originErr := origin.AsSigned()
+	if originErr != nil {
+		log.Critical(originErr.Error())
+	}
 
 	address, err := types.Lookup(dest)
 	if err != nil {

--- a/frame/balances/call_transfer_keep_alive_test.go
+++ b/frame/balances/call_transfer_keep_alive_test.go
@@ -102,33 +102,33 @@ func Test_Call_TransferKeepAlive_Dispatch_Success(t *testing.T) {
 
 	mockMutator.On(
 		"tryMutateAccountWithDust",
-		toAddress.AsAddress32(),
+		toAddress32,
 		mockTypeMutateAccountDataBool,
 	).Return(sc.Result[sc.Encodable]{})
 	mockStoredMap.On(
 		"DepositEvent",
 		newEventTransfer(
 			moduleId,
-			fromAddress.AsAddress32().FixedSequence,
-			toAddress.AsAddress32().FixedSequence,
+			fromAddress32.FixedSequence,
+			toAddress32.FixedSequence,
 			targetValue,
 		),
 	).Return()
 
-	result := target.Dispatch(primitives.NewRawOriginSigned(fromAddress.AsAddress32()), sc.NewVaryingData(toAddress, sc.ToCompact(targetValue)))
+	result := target.Dispatch(primitives.NewRawOriginSigned(fromAddress32), sc.NewVaryingData(toAddress, sc.ToCompact(targetValue)))
 
 	assert.Equal(t, expect, result)
 	mockMutator.AssertCalled(t,
 		"tryMutateAccountWithDust",
-		toAddress.AsAddress32(),
+		toAddress32,
 		mockTypeMutateAccountDataBool,
 	)
 	mockStoredMap.AssertCalled(t,
 		"DepositEvent",
 		newEventTransfer(
 			moduleId,
-			fromAddress.AsAddress32().FixedSequence,
-			toAddress.AsAddress32().FixedSequence,
+			fromAddress32.FixedSequence,
+			toAddress32.FixedSequence,
 			targetValue,
 		),
 	)
@@ -164,7 +164,7 @@ func Test_Call_TransferKeepAlive_Dispatch_CannotLookup(t *testing.T) {
 
 	result := target.
 		Dispatch(
-			primitives.NewRawOriginSigned(fromAddress.AsAddress32()),
+			primitives.NewRawOriginSigned(fromAddress32),
 			sc.NewVaryingData(primitives.NewMultiAddress20(primitives.Address20{}), sc.ToCompact(targetValue)),
 		)
 

--- a/frame/balances/call_transfer_test.go
+++ b/frame/balances/call_transfer_test.go
@@ -118,7 +118,7 @@ func Test_Call_Transfer_Dispatch_Success(t *testing.T) {
 	}
 
 	result := target.
-		Dispatch(primitives.NewRawOriginSigned(fromAddress.AsAddress32()), sc.NewVaryingData(fromAddress, sc.ToCompact(targetValue)))
+		Dispatch(primitives.NewRawOriginSigned(fromAddress32), sc.NewVaryingData(fromAddress, sc.ToCompact(targetValue)))
 
 	assert.Equal(t, expected, result)
 }
@@ -147,7 +147,7 @@ func Test_Call_Transfer_Dispatch_CannotLookup(t *testing.T) {
 	}
 
 	result := target.Dispatch(
-		primitives.NewRawOriginSigned(fromAddress.AsAddress32()),
+		primitives.NewRawOriginSigned(fromAddress32),
 		sc.NewVaryingData(primitives.NewMultiAddress20(primitives.Address20{}), sc.ToCompact(targetValue)),
 	)
 
@@ -169,7 +169,7 @@ func Test_transfer_New(t *testing.T) {
 func Test_transfer_Success(t *testing.T) {
 	target := setupTransfer()
 
-	result := target.transfer(primitives.NewRawOriginSigned(fromAddress.AsAddress32()), fromAddress, targetValue)
+	result := target.transfer(primitives.NewRawOriginSigned(fromAddress32), fromAddress, targetValue)
 
 	assert.Equal(t, sc.VaryingData(nil), result)
 }
@@ -186,7 +186,7 @@ func Test_transfer_InvalidLookup(t *testing.T) {
 	target := setupTransfer()
 
 	result := target.
-		transfer(primitives.NewRawOriginSigned(fromAddress.AsAddress32()), primitives.NewMultiAddress20(primitives.Address20{}), targetValue)
+		transfer(primitives.NewRawOriginSigned(fromAddress32), primitives.NewMultiAddress20(primitives.Address20{}), targetValue)
 
 	assert.Equal(t, primitives.NewDispatchErrorCannotLookup(), result)
 }
@@ -196,32 +196,32 @@ func Test_transfer_trans_Success(t *testing.T) {
 
 	mockMutator.On(
 		"tryMutateAccountWithDust",
-		toAddress.AsAddress32(),
+		toAddress32,
 		mockTypeMutateAccountDataBool,
 	).Return(sc.Result[sc.Encodable]{})
 	mockStoredMap.On(
 		"DepositEvent",
-		newEventTransfer(moduleId, fromAddress.AsAddress32().FixedSequence, toAddress.AsAddress32().FixedSequence, targetValue),
+		newEventTransfer(moduleId, fromAddress32.FixedSequence, toAddress32.FixedSequence, targetValue),
 	).Return()
 
-	result := target.trans(fromAddress.AsAddress32(), toAddress.AsAddress32(), targetValue, primitives.ExistenceRequirementKeepAlive)
+	result := target.trans(fromAddress32, toAddress32, targetValue, primitives.ExistenceRequirementKeepAlive)
 
 	assert.Equal(t, sc.VaryingData(nil), result)
 	mockMutator.AssertCalled(t,
 		"tryMutateAccountWithDust",
-		toAddress.AsAddress32(),
+		toAddress32,
 		mockTypeMutateAccountDataBool,
 	)
 	mockStoredMap.AssertCalled(t,
 		"DepositEvent",
-		newEventTransfer(moduleId, fromAddress.AsAddress32().FixedSequence, toAddress.AsAddress32().FixedSequence, targetValue),
+		newEventTransfer(moduleId, fromAddress32.FixedSequence, toAddress32.FixedSequence, targetValue),
 	)
 }
 
 func Test_transfer_trans_ZeroValue(t *testing.T) {
 	target := setupTransfer()
 
-	result := target.trans(fromAddress.AsAddress32(), toAddress.AsAddress32(), sc.NewU128(0), primitives.ExistenceRequirementAllowDeath)
+	result := target.trans(fromAddress32, toAddress32, sc.NewU128(0), primitives.ExistenceRequirementAllowDeath)
 
 	assert.Equal(t, sc.VaryingData(nil), result)
 	mockMutator.AssertNotCalled(t, "tryMutateAccountWithDust", mock.Anything, mock.Anything)
@@ -231,7 +231,7 @@ func Test_transfer_trans_ZeroValue(t *testing.T) {
 func Test_transfer_trans_EqualFromTo(t *testing.T) {
 	target := setupTransfer()
 
-	result := target.trans(fromAddress.AsAddress32(), fromAddress.AsAddress32(), targetValue, primitives.ExistenceRequirementAllowDeath)
+	result := target.trans(fromAddress32, fromAddress32, targetValue, primitives.ExistenceRequirementAllowDeath)
 
 	assert.Equal(t, sc.VaryingData(nil), result)
 	mockMutator.AssertNotCalled(t, "tryMutateAccountWithDust", mock.Anything, mock.Anything)
@@ -248,16 +248,16 @@ func Test_transfer_trans_MutateAccountWithDust_Fails(t *testing.T) {
 
 	mockMutator.On(
 		"tryMutateAccountWithDust",
-		toAddress.AsAddress32(),
+		toAddress32,
 		mockTypeMutateAccountDataBool,
 	).Return(error)
 
-	result := target.trans(fromAddress.AsAddress32(), toAddress.AsAddress32(), targetValue, primitives.ExistenceRequirementKeepAlive)
+	result := target.trans(fromAddress32, toAddress32, targetValue, primitives.ExistenceRequirementKeepAlive)
 
 	assert.Equal(t, expectdError, result)
 	mockMutator.AssertCalled(t,
 		"tryMutateAccountWithDust",
-		toAddress.AsAddress32(),
+		toAddress32,
 		mockTypeMutateAccountDataBool,
 	)
 	mockStoredMap.AssertNotCalled(t, "DepositEvent", mock.Anything)
@@ -267,16 +267,16 @@ func Test_transfer_sanityChecks_Success(t *testing.T) {
 	target := setupTransfer()
 	expected := sc.Result[sc.Encodable]{}
 
-	mockMutator.On("ensureCanWithdraw", targetAddress.AsAddress32(), targetValue, primitives.ReasonsAll, sc.NewU128(0)).Return(sc.VaryingData(nil))
-	mockStoredMap.On("CanDecProviders", targetAddress.AsAddress32()).Return(true, nil)
+	mockMutator.On("ensureCanWithdraw", targetAddress32, targetValue, primitives.ReasonsAll, sc.NewU128(0)).Return(sc.VaryingData(nil))
+	mockStoredMap.On("CanDecProviders", targetAddress32).Return(true, nil)
 
-	result := target.sanityChecks(targetAddress.AsAddress32(), fromAccountData, toAccountData, targetValue, primitives.ExistenceRequirementAllowDeath)
+	result := target.sanityChecks(targetAddress32, fromAccountData, toAccountData, targetValue, primitives.ExistenceRequirementAllowDeath)
 
 	assert.Equal(t, expected, result)
 	assert.Equal(t, sc.NewU128(0), fromAccountData.Free)
 	assert.Equal(t, sc.NewU128(6), toAccountData.Free)
-	mockMutator.AssertCalled(t, "ensureCanWithdraw", targetAddress.AsAddress32(), targetValue, primitives.ReasonsAll, sc.NewU128(0))
-	mockStoredMap.AssertCalled(t, "CanDecProviders", targetAddress.AsAddress32())
+	mockMutator.AssertCalled(t, "ensureCanWithdraw", targetAddress32, targetValue, primitives.ReasonsAll, sc.NewU128(0))
+	mockStoredMap.AssertCalled(t, "CanDecProviders", targetAddress32)
 }
 
 func Test_transfer_sanityChecks_InsufficientBalance(t *testing.T) {
@@ -290,7 +290,7 @@ func Test_transfer_sanityChecks_InsufficientBalance(t *testing.T) {
 		}),
 	}
 
-	result := target.sanityChecks(targetAddress.AsAddress32(), fromAccountData, toAccountData, sc.NewU128(6), primitives.ExistenceRequirementKeepAlive)
+	result := target.sanityChecks(targetAddress32, fromAccountData, toAccountData, sc.NewU128(6), primitives.ExistenceRequirementKeepAlive)
 
 	assert.Equal(t, expected, result)
 	assert.Equal(t, sc.NewU128(5), fromAccountData.Free)
@@ -307,7 +307,7 @@ func Test_transfer_sanityChecks_ArithmeticOverflow(t *testing.T) {
 	}
 	toAccountData.Free = sc.MaxU128()
 
-	result := target.sanityChecks(targetAddress.AsAddress32(), fromAccountData, toAccountData, sc.NewU128(1), primitives.ExistenceRequirementKeepAlive)
+	result := target.sanityChecks(targetAddress32, fromAccountData, toAccountData, sc.NewU128(1), primitives.ExistenceRequirementKeepAlive)
 
 	assert.Equal(t, expected, result)
 	assert.Equal(t, sc.NewU128(4), fromAccountData.Free)
@@ -328,7 +328,7 @@ func Test_transfer_sanityChecks_ExistentialDeposit(t *testing.T) {
 	}
 	toAccountData.Free = sc.NewU128(0)
 
-	result := target.sanityChecks(targetAddress.AsAddress32(), fromAccountData, toAccountData, sc.NewU128(0), primitives.ExistenceRequirementKeepAlive)
+	result := target.sanityChecks(targetAddress32, fromAccountData, toAccountData, sc.NewU128(0), primitives.ExistenceRequirementKeepAlive)
 
 	assert.Equal(t, expected, result)
 	assert.Equal(t, sc.NewU128(5), fromAccountData.Free)
@@ -344,14 +344,14 @@ func Test_transfer_sanityChecks_CannotWithdraw(t *testing.T) {
 		HasError: true,
 		Value:    expectedError,
 	}
-	mockMutator.On("ensureCanWithdraw", targetAddress.AsAddress32(), targetValue, primitives.ReasonsAll, sc.NewU128(0)).Return(expectedError)
+	mockMutator.On("ensureCanWithdraw", targetAddress32, targetValue, primitives.ReasonsAll, sc.NewU128(0)).Return(expectedError)
 
-	result := target.sanityChecks(targetAddress.AsAddress32(), fromAccountData, toAccountData, targetValue, primitives.ExistenceRequirementAllowDeath)
+	result := target.sanityChecks(targetAddress32, fromAccountData, toAccountData, targetValue, primitives.ExistenceRequirementAllowDeath)
 
 	assert.Equal(t, expected, result)
 	assert.Equal(t, sc.NewU128(0), fromAccountData.Free)
 	assert.Equal(t, sc.NewU128(6), toAccountData.Free)
-	mockMutator.AssertCalled(t, "ensureCanWithdraw", targetAddress.AsAddress32(), targetValue, primitives.ReasonsAll, sc.NewU128(0))
+	mockMutator.AssertCalled(t, "ensureCanWithdraw", targetAddress32, targetValue, primitives.ReasonsAll, sc.NewU128(0))
 }
 
 func Test_transfer_sanityChecks_KeepAlive(t *testing.T) {
@@ -364,42 +364,42 @@ func Test_transfer_sanityChecks_KeepAlive(t *testing.T) {
 			Message: sc.NewOption[sc.Str](nil),
 		}),
 	}
-	mockMutator.On("ensureCanWithdraw", targetAddress.AsAddress32(), targetValue, primitives.ReasonsAll, sc.NewU128(0)).Return(sc.VaryingData(nil))
-	mockStoredMap.On("CanDecProviders", targetAddress.AsAddress32()).Return(false, nil)
+	mockMutator.On("ensureCanWithdraw", targetAddress32, targetValue, primitives.ReasonsAll, sc.NewU128(0)).Return(sc.VaryingData(nil))
+	mockStoredMap.On("CanDecProviders", targetAddress32).Return(false, nil)
 
-	result := target.sanityChecks(targetAddress.AsAddress32(), fromAccountData, toAccountData, targetValue, primitives.ExistenceRequirementAllowDeath)
+	result := target.sanityChecks(targetAddress32, fromAccountData, toAccountData, targetValue, primitives.ExistenceRequirementAllowDeath)
 
 	assert.Equal(t, expected, result)
 	assert.Equal(t, sc.NewU128(0), fromAccountData.Free)
 	assert.Equal(t, sc.NewU128(6), toAccountData.Free)
-	mockMutator.AssertCalled(t, "ensureCanWithdraw", targetAddress.AsAddress32(), targetValue, primitives.ReasonsAll, sc.NewU128(0))
-	mockStoredMap.AssertCalled(t, "CanDecProviders", targetAddress.AsAddress32())
+	mockMutator.AssertCalled(t, "ensureCanWithdraw", targetAddress32, targetValue, primitives.ReasonsAll, sc.NewU128(0))
+	mockStoredMap.AssertCalled(t, "CanDecProviders", targetAddress32)
 }
 
 func Test_transfer_reducibleBalance_NotKeepAlive(t *testing.T) {
 	target := setupTransfer()
-	mockStoredMap.On("Get", targetAddress.AsAddress32().FixedSequence).Return(accountInfo, nil)
-	mockStoredMap.On("CanDecProviders", targetAddress.AsAddress32()).Return(true, nil)
+	mockStoredMap.On("Get", targetAddress32.FixedSequence).Return(accountInfo, nil)
+	mockStoredMap.On("CanDecProviders", targetAddress32).Return(true, nil)
 
-	result, err := target.reducibleBalance(targetAddress.AsAddress32(), false)
+	result, err := target.reducibleBalance(targetAddress32, false)
 	assert.Nil(t, err)
 
 	assert.Equal(t, accountInfo.Data.Free, result)
-	mockStoredMap.AssertCalled(t, "Get", targetAddress.AsAddress32().FixedSequence)
-	mockStoredMap.AssertCalled(t, "CanDecProviders", targetAddress.AsAddress32())
+	mockStoredMap.AssertCalled(t, "Get", targetAddress32.FixedSequence)
+	mockStoredMap.AssertCalled(t, "CanDecProviders", targetAddress32)
 }
 
 func Test_transfer_reducibleBalance_KeepAlive(t *testing.T) {
 	target := setupTransfer()
-	mockStoredMap.On("Get", targetAddress.AsAddress32().FixedSequence).Return(accountInfo, nil)
-	mockStoredMap.On("CanDecProviders", targetAddress.AsAddress32()).Return(false, nil)
+	mockStoredMap.On("Get", targetAddress32.FixedSequence).Return(accountInfo, nil)
+	mockStoredMap.On("CanDecProviders", targetAddress32).Return(false, nil)
 
-	result, err := target.reducibleBalance(targetAddress.AsAddress32(), true)
+	result, err := target.reducibleBalance(targetAddress32, true)
 	assert.Nil(t, err)
 
 	assert.Equal(t, accountInfo.Data.Free.Sub(existentialDeposit), result)
-	mockStoredMap.AssertCalled(t, "Get", targetAddress.AsAddress32().FixedSequence)
-	mockStoredMap.AssertCalled(t, "CanDecProviders", targetAddress.AsAddress32())
+	mockStoredMap.AssertCalled(t, "Get", targetAddress32.FixedSequence)
+	mockStoredMap.AssertCalled(t, "CanDecProviders", targetAddress32)
 }
 
 func setupCallTransfer() callTransfer {

--- a/frame/balances/events_test.go
+++ b/frame/balances/events_test.go
@@ -13,14 +13,14 @@ func Test_Balances_DecodeEvent_Endowed(t *testing.T) {
 	buffer := &bytes.Buffer{}
 	buffer.WriteByte(moduleId)
 	buffer.Write(EventEndowed.Bytes())
-	buffer.Write(targetAddress.AsAddress32().Bytes())
+	buffer.Write(targetAddress32.Bytes())
 	buffer.Write(targetValue.Bytes())
 
 	result, err := DecodeEvent(moduleId, buffer)
 	assert.Nil(t, err)
 
 	assert.Equal(t,
-		sc.NewVaryingData(sc.U8(moduleId), EventEndowed, targetAddress.AsAddress32().FixedSequence, targetValue),
+		sc.NewVaryingData(sc.U8(moduleId), EventEndowed, targetAddress32.FixedSequence, targetValue),
 		result,
 	)
 }
@@ -29,14 +29,14 @@ func Test_Balances_DecodeEvent_DustLost(t *testing.T) {
 	buffer := &bytes.Buffer{}
 	buffer.WriteByte(moduleId)
 	buffer.Write(EventDustLost.Bytes())
-	buffer.Write(targetAddress.AsAddress32().Bytes())
+	buffer.Write(targetAddress32.Bytes())
 	buffer.Write(targetValue.Bytes())
 
 	result, err := DecodeEvent(moduleId, buffer)
 	assert.Nil(t, err)
 
 	assert.Equal(t,
-		sc.NewVaryingData(sc.U8(moduleId), EventDustLost, targetAddress.AsAddress32().FixedSequence, targetValue),
+		sc.NewVaryingData(sc.U8(moduleId), EventDustLost, targetAddress32.FixedSequence, targetValue),
 		result,
 	)
 }
@@ -45,14 +45,14 @@ func Test_Balances_DecodeEvent_Transfer(t *testing.T) {
 	buffer := &bytes.Buffer{}
 	buffer.WriteByte(moduleId)
 	buffer.Write(EventTransfer.Bytes())
-	buffer.Write(fromAddress.AsAddress32().Bytes())
-	buffer.Write(toAddress.AsAddress32().Bytes())
+	buffer.Write(fromAddress32.Bytes())
+	buffer.Write(toAddress32.Bytes())
 	buffer.Write(targetValue.Bytes())
 
 	result, _ := DecodeEvent(moduleId, buffer)
 
 	assert.Equal(t,
-		sc.NewVaryingData(sc.U8(moduleId), EventTransfer, fromAddress.AsAddress32().FixedSequence, toAddress.AsAddress32().FixedSequence, targetValue),
+		sc.NewVaryingData(sc.U8(moduleId), EventTransfer, fromAddress32.FixedSequence, toAddress32.FixedSequence, targetValue),
 		result,
 	)
 }
@@ -61,7 +61,7 @@ func Test_Balances_DecodeEvent_BalanceSet(t *testing.T) {
 	buffer := &bytes.Buffer{}
 	buffer.WriteByte(moduleId)
 	buffer.Write(EventBalanceSet.Bytes())
-	buffer.Write(targetAddress.AsAddress32().Bytes())
+	buffer.Write(targetAddress32.Bytes())
 	buffer.Write(newFree.Bytes())
 	buffer.Write(newReserved.Bytes())
 
@@ -69,7 +69,7 @@ func Test_Balances_DecodeEvent_BalanceSet(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t,
-		sc.NewVaryingData(sc.U8(moduleId), EventBalanceSet, targetAddress.AsAddress32().FixedSequence, newFree, newReserved),
+		sc.NewVaryingData(sc.U8(moduleId), EventBalanceSet, targetAddress32.FixedSequence, newFree, newReserved),
 		result,
 	)
 }
@@ -78,14 +78,14 @@ func Test_Balances_DecodeEvent_Reserved(t *testing.T) {
 	buffer := &bytes.Buffer{}
 	buffer.WriteByte(moduleId)
 	buffer.Write(EventReserved.Bytes())
-	buffer.Write(targetAddress.AsAddress32().Bytes())
+	buffer.Write(targetAddress32.Bytes())
 	buffer.Write(targetValue.Bytes())
 
 	result, err := DecodeEvent(moduleId, buffer)
 	assert.Nil(t, err)
 
 	assert.Equal(t,
-		sc.NewVaryingData(sc.U8(moduleId), EventReserved, targetAddress.AsAddress32().FixedSequence, targetValue),
+		sc.NewVaryingData(sc.U8(moduleId), EventReserved, targetAddress32.FixedSequence, targetValue),
 		result,
 	)
 }
@@ -94,14 +94,14 @@ func Test_Balances_DecodeEvent_Unreserved(t *testing.T) {
 	buffer := &bytes.Buffer{}
 	buffer.WriteByte(moduleId)
 	buffer.Write(EventUnreserved.Bytes())
-	buffer.Write(targetAddress.AsAddress32().Bytes())
+	buffer.Write(targetAddress32.Bytes())
 	buffer.Write(targetValue.Bytes())
 
 	result, err := DecodeEvent(moduleId, buffer)
 	assert.Nil(t, err)
 
 	assert.Equal(t,
-		sc.NewVaryingData(sc.U8(moduleId), EventUnreserved, targetAddress.AsAddress32().FixedSequence, targetValue),
+		sc.NewVaryingData(sc.U8(moduleId), EventUnreserved, targetAddress32.FixedSequence, targetValue),
 		result,
 	)
 }
@@ -110,8 +110,8 @@ func Test_Balances_DecodeEvent_ReserveRepatriated(t *testing.T) {
 	buffer := &bytes.Buffer{}
 	buffer.WriteByte(moduleId)
 	buffer.Write(EventReserveRepatriated.Bytes())
-	buffer.Write(fromAddress.AsAddress32().Bytes())
-	buffer.Write(toAddress.AsAddress32().Bytes())
+	buffer.Write(fromAddress32.Bytes())
+	buffer.Write(toAddress32.Bytes())
 	buffer.Write(targetValue.Bytes())
 	buffer.Write(types.BalanceStatusFree.Bytes())
 
@@ -122,8 +122,8 @@ func Test_Balances_DecodeEvent_ReserveRepatriated(t *testing.T) {
 		sc.NewVaryingData(
 			sc.U8(moduleId),
 			EventReserveRepatriated,
-			fromAddress.AsAddress32().FixedSequence,
-			toAddress.AsAddress32().FixedSequence,
+			fromAddress32.FixedSequence,
+			toAddress32.FixedSequence,
 			targetValue, types.BalanceStatusFree),
 		result,
 	)
@@ -133,14 +133,14 @@ func Test_Balances_DecodeEvent_Deposit(t *testing.T) {
 	buffer := &bytes.Buffer{}
 	buffer.WriteByte(moduleId)
 	buffer.Write(EventDeposit.Bytes())
-	buffer.Write(targetAddress.AsAddress32().Bytes())
+	buffer.Write(targetAddress32.Bytes())
 	buffer.Write(targetValue.Bytes())
 
 	result, err := DecodeEvent(moduleId, buffer)
 	assert.Nil(t, err)
 
 	assert.Equal(t,
-		sc.NewVaryingData(sc.U8(moduleId), EventDeposit, targetAddress.AsAddress32().FixedSequence, targetValue),
+		sc.NewVaryingData(sc.U8(moduleId), EventDeposit, targetAddress32.FixedSequence, targetValue),
 		result,
 	)
 }
@@ -149,14 +149,14 @@ func Test_Balances_DecodeEvent_Withdraw(t *testing.T) {
 	buffer := &bytes.Buffer{}
 	buffer.WriteByte(moduleId)
 	buffer.Write(EventWithdraw.Bytes())
-	buffer.Write(targetAddress.AsAddress32().Bytes())
+	buffer.Write(targetAddress32.Bytes())
 	buffer.Write(targetValue.Bytes())
 
 	result, err := DecodeEvent(moduleId, buffer)
 	assert.Nil(t, err)
 
 	assert.Equal(t,
-		sc.NewVaryingData(sc.U8(moduleId), EventWithdraw, targetAddress.AsAddress32().FixedSequence, targetValue),
+		sc.NewVaryingData(sc.U8(moduleId), EventWithdraw, targetAddress32.FixedSequence, targetValue),
 		result,
 	)
 }
@@ -165,14 +165,14 @@ func Test_Balances_DecodeEvent_Slashed(t *testing.T) {
 	buffer := &bytes.Buffer{}
 	buffer.WriteByte(moduleId)
 	buffer.Write(EventSlashed.Bytes())
-	buffer.Write(targetAddress.AsAddress32().Bytes())
+	buffer.Write(targetAddress32.Bytes())
 	buffer.Write(targetValue.Bytes())
 
 	result, err := DecodeEvent(moduleId, buffer)
 	assert.Nil(t, err)
 
 	assert.Equal(t,
-		sc.NewVaryingData(sc.U8(moduleId), EventSlashed, targetAddress.AsAddress32().FixedSequence, targetValue),
+		sc.NewVaryingData(sc.U8(moduleId), EventSlashed, targetAddress32.FixedSequence, targetValue),
 		result,
 	)
 }

--- a/frame/balances/module.go
+++ b/frame/balances/module.go
@@ -74,7 +74,9 @@ func (m Module) PreDispatch(_ primitives.Call) (sc.Empty, primitives.Transaction
 }
 
 func (m Module) ValidateUnsigned(_ primitives.TransactionSource, _ primitives.Call) (primitives.ValidTransaction, primitives.TransactionValidityError) {
-	return primitives.ValidTransaction{}, primitives.NewTransactionValidityError(primitives.NewUnknownTransactionNoUnsignedValidator())
+	// TODO https://github.com/LimeChain/gosemble/issues/271
+	unknownTransactionNoUnsignedValidator, _ := primitives.NewTransactionValidityError(primitives.NewUnknownTransactionNoUnsignedValidator())
+	return primitives.ValidTransaction{}, unknownTransactionNoUnsignedValidator
 }
 
 // DepositIntoExisting deposits `value` into the free balance of an existing target account `who`.

--- a/frame/executive/executive_test.go
+++ b/frame/executive/executive_test.go
@@ -72,7 +72,7 @@ var (
 	blockNumber = sc.U64(1)
 
 	blake256Hash = []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31}
-	blockHash    = primitives.NewBlake2bHash(sc.BytesToSequenceU8(blake256Hash)...)
+	blockHash, _ = primitives.NewBlake2bHash(sc.BytesToSequenceU8(blake256Hash)...)
 
 	header = primitives.Header{
 		Number:     blockNumber,
@@ -91,19 +91,19 @@ var (
 var (
 	transactionValidityError primitives.TransactionValidityError
 
-	unknownTransactionCannotLookupError = primitives.NewTransactionValidityError(
+	unknownTransactionCannotLookupError, _ = primitives.NewTransactionValidityError(
 		primitives.NewUnknownTransactionCannotLookup(),
 	)
 
-	invalidTransactionExhaustsResourcesError = primitives.NewTransactionValidityError(
+	invalidTransactionExhaustsResourcesError, _ = primitives.NewTransactionValidityError(
 		primitives.NewInvalidTransactionExhaustsResources(),
 	)
 
-	invalidTransactionBadMandatory = primitives.NewTransactionValidityError(
+	invalidTransactionBadMandatory, _ = primitives.NewTransactionValidityError(
 		primitives.NewInvalidTransactionBadMandatory(),
 	)
 
-	invalidTransactionMandatoryValidation = primitives.NewTransactionValidityError(
+	invalidTransactionMandatoryValidation, _ = primitives.NewTransactionValidityError(
 		primitives.NewInvalidTransactionMandatoryValidation(),
 	)
 
@@ -228,7 +228,7 @@ func Test_Executive_ExecuteBlock_InvalidParentHash(t *testing.T) {
 	mockSystemModule.On("RegisterExtraWeightUnchecked", primitives.WeightFromParts(4, 4), dispatchClassMandatory)
 	mockSystemModule.On("NoteFinishedInitialize")
 
-	invalidParentHash := primitives.NewBlake2bHash(sc.BytesToSequenceU8([]byte("abcdefghijklmnopqrstuvwxyz123450"))...)
+	invalidParentHash, _ := primitives.NewBlake2bHash(sc.BytesToSequenceU8([]byte("abcdefghijklmnopqrstuvwxyz123450"))...)
 	mockSystemModule.On("StorageBlockHash", header.Number-1).Return(invalidParentHash, nil)
 
 	assert.PanicsWithValue(t, "parent hash should be valid", func() {
@@ -395,7 +395,8 @@ func Test_Executive_ApplyExtrinsic_Success(t *testing.T) {
 
 	mockSystemModule.AssertCalled(t, "NoteExtrinsic", mockUncheckedExtrinsic.Bytes())
 	mockSystemModule.AssertCalled(t, "NoteAppliedExtrinsic", dispatchResultWithPostInfo, dispatchInfo)
-	assert.Equal(t, primitives.NewDispatchOutcome(dispatchResultWithPostInfo.Err.Error), outcome)
+	dispatchOutcomeWithPostInfo, _ := primitives.NewDispatchOutcome(dispatchResultWithPostInfo.Err.Error)
+	assert.Equal(t, dispatchOutcomeWithPostInfo, outcome)
 	assert.Equal(t, transactionValidityError, err)
 }
 

--- a/frame/grandpa/module.go
+++ b/frame/grandpa/module.go
@@ -77,7 +77,9 @@ func (m Module) PreDispatch(_ primitives.Call) (sc.Empty, primitives.Transaction
 }
 
 func (m Module) ValidateUnsigned(_ primitives.TransactionSource, _ primitives.Call) (primitives.ValidTransaction, primitives.TransactionValidityError) {
-	return primitives.ValidTransaction{}, primitives.NewTransactionValidityError(primitives.NewUnknownTransactionNoUnsignedValidator())
+	// TODO https://github.com/LimeChain/gosemble/issues/271
+	unknownTransactionNoUnsignedValidator, _ := primitives.NewTransactionValidityError(primitives.NewUnknownTransactionNoUnsignedValidator())
+	return primitives.ValidTransaction{}, unknownTransactionNoUnsignedValidator
 }
 
 func (m Module) Authorities() (sc.Sequence[primitives.Authority], error) {

--- a/frame/grandpa/module_test.go
+++ b/frame/grandpa/module_test.go
@@ -15,6 +15,10 @@ import (
 const moduleId = sc.U8(3)
 
 var (
+	unknownTransactionNoUnsignedValidator, _ = primitives.NewTransactionValidityError(primitives.NewUnknownTransactionNoUnsignedValidator())
+)
+
+var (
 	mockStorageAuthorities *mocks.StorageValue[primitives.VersionedAuthorityList]
 	target                 Module
 )
@@ -67,7 +71,7 @@ func Test_Module_ValidateUnsigned(t *testing.T) {
 
 	result, err := target.ValidateUnsigned(primitives.NewTransactionSourceLocal(), new(mocks.Call))
 
-	assert.Equal(t, primitives.NewTransactionValidityError(primitives.NewUnknownTransactionNoUnsignedValidator()), err)
+	assert.Equal(t, unknownTransactionNoUnsignedValidator, err)
 	assert.Equal(t, primitives.ValidTransaction{}, result)
 }
 

--- a/frame/system/call_remark_test.go
+++ b/frame/system/call_remark_test.go
@@ -173,7 +173,8 @@ func Test_EnsureSignedOrRoot_Root(t *testing.T) {
 func Test_EnsureSignedOrRoot_Signed(t *testing.T) {
 	slice := make([]sc.U8, 32)
 	seq := sc.NewFixedSequence[sc.U8](32, slice...)
-	address := primitives.NewAddress32(seq...)
+	address, e := primitives.NewAddress32(seq...)
+	assert.Nil(t, e)
 
 	r, err := EnsureSignedOrRoot(primitives.NewRawOriginSigned(address))
 

--- a/frame/system/events_test.go
+++ b/frame/system/events_test.go
@@ -102,7 +102,9 @@ func Test_System_DecodeEvent_KilledAccount(t *testing.T) {
 
 func Test_System_DecodeEvent_Remarked(t *testing.T) {
 	emptyHash := [32]sc.U8{}
-	hash := types.NewH256(emptyHash[:]...)
+	hash, err := types.NewH256(emptyHash[:]...)
+	assert.Nil(t, err)
+
 	buffer := &bytes.Buffer{}
 	buffer.WriteByte(moduleId)
 	buffer.Write(EventRemarked.Bytes())

--- a/frame/system/extensions/check_genesis.go
+++ b/frame/system/extensions/check_genesis.go
@@ -30,7 +30,9 @@ func (cg CheckGenesis) Bytes() []byte {
 func (cg CheckGenesis) AdditionalSigned() (primitives.AdditionalSigned, primitives.TransactionValidityError) {
 	hash, err := cg.module.StorageBlockHash(0)
 	if err != nil {
-		return nil, primitives.NewTransactionValidityError(sc.Str(err.Error()))
+		// TODO https://github.com/LimeChain/gosemble/issues/271
+		transactionValidityError, _ := primitives.NewTransactionValidityError(sc.Str(err.Error()))
+		return nil, transactionValidityError
 	}
 
 	return sc.NewVaryingData(primitives.H256(hash)), nil

--- a/frame/system/extensions/check_mortality_test.go
+++ b/frame/system/extensions/check_mortality_test.go
@@ -14,6 +14,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var (
+	invalidTransactionAncientBirthBlock, _ = primitives.NewTransactionValidityError(primitives.NewInvalidTransactionAncientBirthBlock())
+)
+
 func Test_CheckMortality_Encode(t *testing.T) {
 	era := primitives.NewImmortalEra()
 	buffer := &bytes.Buffer{}
@@ -92,7 +96,7 @@ func Test_CheckMortality_AdditionalSigned_Failed(t *testing.T) {
 
 	result, err := target.AdditionalSigned()
 
-	assert.Equal(t, primitives.NewTransactionValidityError(primitives.NewInvalidTransactionAncientBirthBlock()), err)
+	assert.Equal(t, invalidTransactionAncientBirthBlock, err)
 	assert.Nil(t, result)
 
 	mockModule.AssertCalled(t, "StorageBlockNumber")

--- a/frame/system/extensions/check_non_zero_sender.go
+++ b/frame/system/extensions/check_non_zero_sender.go
@@ -34,7 +34,9 @@ func (c CheckNonZeroAddress) Validate(who primitives.Address32, _call primitives
 	// Checks signed transactions but will fail
 	// before this check if the address is all zeros.
 	if reflect.DeepEqual(who, constants.ZeroAddress) {
-		return primitives.ValidTransaction{}, primitives.NewTransactionValidityError(primitives.NewInvalidTransactionBadSigner())
+		// TODO https://github.com/LimeChain/gosemble/issues/271
+		invalidTransactionBadSigner, _ := primitives.NewTransactionValidityError(primitives.NewInvalidTransactionBadSigner())
+		return primitives.ValidTransaction{}, invalidTransactionBadSigner
 	}
 
 	return primitives.DefaultValidTransaction(), nil

--- a/frame/system/extensions/check_non_zero_sender_test.go
+++ b/frame/system/extensions/check_non_zero_sender_test.go
@@ -12,6 +12,10 @@ import (
 )
 
 var (
+	invalidTransactionBadSigner, _ = primitives.NewTransactionValidityError(primitives.NewInvalidTransactionBadSigner())
+)
+
+var (
 	targetAddress = constants.ZeroAddress
 )
 
@@ -64,11 +68,10 @@ func Test_CheckNonZeroAddress_Validate_Success(t *testing.T) {
 
 func Test_CheckNonZeroAddress_Validate_Fails(t *testing.T) {
 	target := setupCheckNonZeroSender()
-	expect := primitives.NewTransactionValidityError(primitives.NewInvalidTransactionBadSigner())
 
 	result, err := target.Validate(constants.ZeroAddress, nil, nil, sc.Compact{})
 
-	assert.Equal(t, expect, err)
+	assert.Equal(t, invalidTransactionBadSigner, err)
 	assert.Equal(t, primitives.ValidTransaction{}, result)
 }
 

--- a/frame/system/extensions/check_nonce.go
+++ b/frame/system/extensions/check_nonce.go
@@ -43,11 +43,15 @@ func (cn CheckNonce) AdditionalSigned() (primitives.AdditionalSigned, primitives
 func (cn CheckNonce) Validate(who primitives.Address32, _call primitives.Call, _info *primitives.DispatchInfo, _length sc.Compact) (primitives.ValidTransaction, primitives.TransactionValidityError) {
 	account, err := cn.systemModule.StorageAccount(who.FixedSequence)
 	if err != nil {
-		return primitives.ValidTransaction{}, primitives.NewTransactionValidityError(sc.Str(err.Error()))
+		// TODO https://github.com/LimeChain/gosemble/issues/271
+		transactionValidityError, _ := primitives.NewTransactionValidityError(sc.Str(err.Error()))
+		return primitives.ValidTransaction{}, transactionValidityError
 	}
 
 	if cn.nonce < account.Nonce {
-		return primitives.ValidTransaction{}, primitives.NewTransactionValidityError(primitives.NewInvalidTransactionStale())
+		// TODO https://github.com/LimeChain/gosemble/issues/271
+		invalidTransactionStale, _ := primitives.NewTransactionValidityError(primitives.NewInvalidTransactionStale())
+		return primitives.ValidTransaction{}, invalidTransactionStale
 	}
 
 	encoded := who.Bytes()
@@ -79,17 +83,20 @@ func (cn CheckNonce) ValidateUnsigned(_call primitives.Call, info *primitives.Di
 func (cn CheckNonce) PreDispatch(who primitives.Address32, call primitives.Call, info *primitives.DispatchInfo, length sc.Compact) (primitives.Pre, primitives.TransactionValidityError) {
 	account, err := cn.systemModule.StorageAccount(who.FixedSequence)
 	if err != nil {
-		return primitives.Pre{}, primitives.NewTransactionValidityError(sc.Str(err.Error()))
+		// TODO https://github.com/LimeChain/gosemble/issues/271
+		transactionValidityError, _ := primitives.NewTransactionValidityError(sc.Str(err.Error()))
+		return primitives.Pre{}, transactionValidityError
 	}
 
 	if cn.nonce != account.Nonce {
-		var err primitives.TransactionValidityError
+		var transactionValidityError primitives.TransactionValidityError
 		if cn.nonce < account.Nonce {
-			err = primitives.NewTransactionValidityError(primitives.NewInvalidTransactionStale())
+			// TODO https://github.com/LimeChain/gosemble/issues/271
+			transactionValidityError, _ = primitives.NewTransactionValidityError(primitives.NewInvalidTransactionStale())
 		} else {
-			err = primitives.NewTransactionValidityError(primitives.NewInvalidTransactionFuture())
+			transactionValidityError, _ = primitives.NewTransactionValidityError(primitives.NewInvalidTransactionFuture())
 		}
-		return primitives.Pre{}, err
+		return primitives.Pre{}, transactionValidityError
 	}
 
 	account.Nonce = account.Nonce + 1

--- a/frame/system/extensions/check_nonce_test.go
+++ b/frame/system/extensions/check_nonce_test.go
@@ -15,6 +15,11 @@ import (
 )
 
 var (
+	invalidTransactionStale, _  = primitives.NewTransactionValidityError(primitives.NewInvalidTransactionStale())
+	invalidTransactionFuture, _ = primitives.NewTransactionValidityError(primitives.NewInvalidTransactionFuture())
+)
+
+var (
 	oneAddress = constants.OneAddress
 )
 
@@ -129,7 +134,6 @@ func Test_CheckNonce_Validate_Fails(t *testing.T) {
 	accountInfo := primitives.AccountInfo{
 		Nonce: 1,
 	}
-	expect := primitives.NewTransactionValidityError(primitives.NewInvalidTransactionStale())
 
 	target := setupCheckNonce()
 	target.nonce = nonce
@@ -138,7 +142,7 @@ func Test_CheckNonce_Validate_Fails(t *testing.T) {
 
 	result, err := target.Validate(oneAddress, nil, nil, sc.Compact{})
 
-	assert.Equal(t, expect, err)
+	assert.Equal(t, invalidTransactionStale, err)
 	assert.Equal(t, primitives.ValidTransaction{}, result)
 	mockModule.AssertCalled(t, "StorageAccount", oneAddress.FixedSequence)
 }
@@ -181,7 +185,6 @@ func Test_CheckNonce_PreDispatch_Fails_Stale(t *testing.T) {
 	accountInfo := primitives.AccountInfo{
 		Nonce: 1,
 	}
-	expect := primitives.NewTransactionValidityError(primitives.NewInvalidTransactionStale())
 
 	target := setupCheckNonce()
 	target.nonce = nonce
@@ -190,7 +193,7 @@ func Test_CheckNonce_PreDispatch_Fails_Stale(t *testing.T) {
 
 	result, err := target.PreDispatch(oneAddress, nil, nil, sc.Compact{})
 
-	assert.Equal(t, expect, err)
+	assert.Equal(t, invalidTransactionStale, err)
 	assert.Equal(t, primitives.Pre{}, result)
 
 	mockModule.AssertCalled(t, "StorageAccount", oneAddress.FixedSequence)
@@ -202,7 +205,6 @@ func Test_CheckNonce_PreDispatch_Fails_Future(t *testing.T) {
 	accountInfo := primitives.AccountInfo{
 		Nonce: 1,
 	}
-	expect := primitives.NewTransactionValidityError(primitives.NewInvalidTransactionFuture())
 
 	target := setupCheckNonce()
 	target.nonce = nonce
@@ -211,7 +213,7 @@ func Test_CheckNonce_PreDispatch_Fails_Future(t *testing.T) {
 
 	result, err := target.PreDispatch(oneAddress, nil, nil, sc.Compact{})
 
-	assert.Equal(t, expect, err)
+	assert.Equal(t, invalidTransactionFuture, err)
 	assert.Equal(t, primitives.Pre{}, result)
 
 	mockModule.AssertCalled(t, "StorageAccount", oneAddress.FixedSequence)

--- a/frame/system/extensions/check_weight_test.go
+++ b/frame/system/extensions/check_weight_test.go
@@ -50,6 +50,10 @@ var (
 	}
 )
 
+var (
+	invalidTransactionExhaustsResources, _ = primitives.NewTransactionValidityError(primitives.NewInvalidTransactionExhaustsResources())
+)
+
 func Test_CheckWeight_AdditionalSigned(t *testing.T) {
 	target := setupCheckWeight()
 
@@ -239,7 +243,6 @@ func Test_CheckWeight_doValidate_InvalidExtrinsicLength(t *testing.T) {
 			},
 		},
 	}
-	expect := primitives.NewTransactionValidityError(primitives.NewInvalidTransactionExhaustsResources())
 
 	mockModule.On("BlockLength").Return(blockLength)
 	mockModule.On("StorageAllExtrinsicsLen").Return(storageLen, nil)
@@ -247,7 +250,7 @@ func Test_CheckWeight_doValidate_InvalidExtrinsicLength(t *testing.T) {
 
 	result, err := target.doValidate(dispatchInfo, sc.ToCompact(length))
 
-	assert.Equal(t, expect, err)
+	assert.Equal(t, invalidTransactionExhaustsResources, err)
 	assert.Equal(t, primitives.ValidTransaction{}, result)
 
 	mockModule.AssertCalled(t, "BlockLength")
@@ -258,14 +261,13 @@ func Test_CheckWeight_doValidate_InvalidExtrinsicLength(t *testing.T) {
 func Test_CheckWeight_doValidate_InvalidBlockLength(t *testing.T) {
 	storageLen := sc.U32(10)
 	target := setupCheckWeight()
-	expect := primitives.NewTransactionValidityError(primitives.NewInvalidTransactionExhaustsResources())
 
 	mockModule.On("BlockLength").Return(blockLength)
 	mockModule.On("StorageAllExtrinsicsLen").Return(storageLen, nil)
 
 	result, err := target.doValidate(dispatchInfo, sc.ToCompact(length))
 
-	assert.Equal(t, expect, err)
+	assert.Equal(t, invalidTransactionExhaustsResources, err)
 	assert.Equal(t, primitives.ValidTransaction{}, result)
 
 	mockModule.AssertCalled(t, "BlockLength")
@@ -310,7 +312,6 @@ func Test_CheckWeight_doPreDispatch_InvalidExtrinsicWeight(t *testing.T) {
 			},
 		},
 	}
-	expect := primitives.NewTransactionValidityError(primitives.NewInvalidTransactionExhaustsResources())
 
 	mockModule.On("BlockLength").Return(blockLength)
 	mockModule.On("StorageAllExtrinsicsLen").Return(storageLen, nil)
@@ -319,7 +320,7 @@ func Test_CheckWeight_doPreDispatch_InvalidExtrinsicWeight(t *testing.T) {
 
 	result := target.doPreDispatch(dispatchInfo, sc.ToCompact(length))
 
-	assert.Equal(t, expect, result)
+	assert.Equal(t, invalidTransactionExhaustsResources, result)
 
 	mockModule.AssertCalled(t, "BlockLength")
 	mockModule.AssertCalled(t, "StorageAllExtrinsicsLen")
@@ -347,7 +348,6 @@ func Test_CheckWeight_doPreDispatch_InvalidBlockWeight(t *testing.T) {
 			},
 		},
 	}
-	expect := primitives.NewTransactionValidityError(primitives.NewInvalidTransactionExhaustsResources())
 
 	mockModule.On("BlockLength").Return(blockLength)
 	mockModule.On("StorageAllExtrinsicsLen").Return(storageLen, nil)
@@ -356,7 +356,7 @@ func Test_CheckWeight_doPreDispatch_InvalidBlockWeight(t *testing.T) {
 
 	result := target.doPreDispatch(dispatchInfo, sc.ToCompact(length))
 
-	assert.Equal(t, expect, result)
+	assert.Equal(t, invalidTransactionExhaustsResources, result)
 
 	mockModule.AssertCalled(t, "BlockLength")
 	mockModule.AssertCalled(t, "StorageAllExtrinsicsLen")
@@ -369,14 +369,13 @@ func Test_CheckWeight_doPreDispatch_InvalidBlockWeight(t *testing.T) {
 func Test_CheckWeight_doPreDispatch_InvalidBlockLength(t *testing.T) {
 	storageLen := sc.U32(10)
 	target := setupCheckWeight()
-	expect := primitives.NewTransactionValidityError(primitives.NewInvalidTransactionExhaustsResources())
 
 	mockModule.On("BlockLength").Return(blockLength)
 	mockModule.On("StorageAllExtrinsicsLen").Return(storageLen, nil)
 
 	result := target.doPreDispatch(dispatchInfo, sc.ToCompact(length))
 
-	assert.Equal(t, expect, result)
+	assert.Equal(t, invalidTransactionExhaustsResources, result)
 
 	mockModule.AssertCalled(t, "BlockLength")
 	mockModule.AssertCalled(t, "StorageAllExtrinsicsLen")
@@ -462,14 +461,13 @@ func Test_CheckWeight_checkBlockLength_InvalidDispatch(t *testing.T) {
 func Test_CheckWeight_checkBlockLength_ExhaustsResources(t *testing.T) {
 	storageLen := sc.U32(10)
 	target := setupCheckWeight()
-	expect := primitives.NewTransactionValidityError(primitives.NewInvalidTransactionExhaustsResources())
 
 	mockModule.On("BlockLength").Return(blockLength)
 	mockModule.On("StorageAllExtrinsicsLen").Return(storageLen, nil)
 
 	result, err := target.checkBlockLength(dispatchInfo, sc.ToCompact(length))
 
-	assert.Equal(t, expect, err)
+	assert.Equal(t, invalidTransactionExhaustsResources, err)
 	assert.Equal(t, sc.U32(0), result)
 
 	mockModule.AssertCalled(t, "BlockLength")
@@ -507,13 +505,12 @@ func Test_CheckWeight_checkExtrinsicWeight_ExhaustsResources(t *testing.T) {
 			},
 		},
 	}
-	expect := primitives.NewTransactionValidityError(primitives.NewInvalidTransactionExhaustsResources())
 
 	mockModule.On("BlockWeights").Return(blockWeight)
 
 	result := target.checkExtrinsicWeight(dispatchInfo)
 
-	assert.Equal(t, expect, result)
+	assert.Equal(t, invalidTransactionExhaustsResources, result)
 
 	mockModule.AssertCalled(t, "BlockWeights")
 }
@@ -562,11 +559,10 @@ func Test_CheckWeight_calculateConsumedWeight_MaxTotal_ExhaustsResources(t *test
 			},
 		},
 	}
-	expect := primitives.NewTransactionValidityError(primitives.NewInvalidTransactionExhaustsResources())
 
 	result, err := target.calculateConsumedWeight(blockWeight, consumedWeight, dispatchInfo)
 
-	assert.Equal(t, expect, err)
+	assert.Equal(t, invalidTransactionExhaustsResources, err)
 	assert.Equal(t, primitives.ConsumedWeight{}, result)
 }
 
@@ -589,11 +585,10 @@ func Test_CheckWeight_calculateConsumsedWeight_TotalMoreThanMaxReserved_Exhausts
 			},
 		},
 	}
-	expect := primitives.NewTransactionValidityError(primitives.NewInvalidTransactionExhaustsResources())
 
 	result, err := target.calculateConsumedWeight(blockWeight, consumedWeight, dispatchInfo)
 
-	assert.Equal(t, expect, err)
+	assert.Equal(t, invalidTransactionExhaustsResources, err)
 	assert.Equal(t, primitives.ConsumedWeight{}, result)
 }
 
@@ -615,11 +610,10 @@ func Test_CheckWeight_calculateConsumedWeight_LessThanMaxTotal_ExhaustsResources
 			},
 		},
 	}
-	expect := primitives.NewTransactionValidityError(primitives.NewInvalidTransactionExhaustsResources())
 
 	result, err := target.calculateConsumedWeight(blockWeight, consumedWeight, dispatchInfo)
 
-	assert.Equal(t, expect, err)
+	assert.Equal(t, invalidTransactionExhaustsResources, err)
 	assert.Equal(t, primitives.ConsumedWeight{}, result)
 }
 

--- a/frame/system/module_test.go
+++ b/frame/system/module_test.go
@@ -87,6 +87,10 @@ var (
 )
 
 var (
+	unknownTransactionNoUnsignedValidator, _ = primitives.NewTransactionValidityError(primitives.NewUnknownTransactionNoUnsignedValidator())
+)
+
+var (
 	mockStorageAccount            *mocks.StorageMap[primitives.PublicKey, primitives.AccountInfo]
 	mockStorageBlockWeight        *mocks.StorageValue[primitives.ConsumedWeight]
 	mockStorageBlockHash          *mocks.StorageMap[sc.U64, primitives.Blake2bHash]
@@ -137,7 +141,7 @@ func Test_Module_ValidateUnsigned(t *testing.T) {
 
 	result, err := target.ValidateUnsigned(primitives.TransactionSource{}, mockCall)
 
-	assert.Equal(t, primitives.NewTransactionValidityError(primitives.NewUnknownTransactionNoUnsignedValidator()), err)
+	assert.Equal(t, unknownTransactionNoUnsignedValidator, err)
 	assert.Equal(t, primitives.ValidTransaction{}, result)
 }
 

--- a/frame/testable/module.go
+++ b/frame/testable/module.go
@@ -45,7 +45,9 @@ func (m Module) PreDispatch(_ primitives.Call) (sc.Empty, primitives.Transaction
 }
 
 func (m Module) ValidateUnsigned(_ primitives.TransactionSource, _ primitives.Call) (primitives.ValidTransaction, primitives.TransactionValidityError) {
-	return primitives.ValidTransaction{}, primitives.NewTransactionValidityError(primitives.NewUnknownTransactionNoUnsignedValidator())
+	// TODO https://github.com/LimeChain/gosemble/issues/271
+	unknownTransactionNoUnsignedValidator, _ := primitives.NewTransactionValidityError(primitives.NewUnknownTransactionNoUnsignedValidator())
+	return primitives.ValidTransaction{}, unknownTransactionNoUnsignedValidator
 }
 
 func (m Module) Metadata() (sc.Sequence[primitives.MetadataType], primitives.MetadataModule) {

--- a/frame/transaction_payment/extensions/charge_transaction.go
+++ b/frame/transaction_payment/extensions/charge_transaction.go
@@ -28,7 +28,9 @@ func (ct chargeTransaction) WithdrawFee(who primitives.Address32, call primitive
 
 	imbalance, err := ct.currencyAdapter.Withdraw(who, fee, sc.U8(withdrawReasons), primitives.ExistenceRequirementKeepAlive)
 	if err != nil {
-		return sc.NewOption[primitives.Balance](nil), primitives.NewTransactionValidityError(primitives.NewInvalidTransactionPayment())
+		// TODO https://github.com/LimeChain/gosemble/issues/271
+		transactionValidityError, _ := primitives.NewTransactionValidityError(primitives.NewInvalidTransactionPayment())
+		return sc.NewOption[primitives.Balance](nil), transactionValidityError
 	}
 
 	return sc.NewOption[primitives.Balance](imbalance), nil
@@ -41,11 +43,15 @@ func (ct chargeTransaction) CorrectAndDepositFee(who primitives.Address32, corre
 
 		refundPositiveImbalance, err := ct.currencyAdapter.DepositIntoExisting(who, refundAmount)
 		if err != nil {
-			return primitives.NewTransactionValidityError(primitives.NewInvalidTransactionPayment())
+			// TODO https://github.com/LimeChain/gosemble/issues/271
+			invalidTransactionPayment, _ := primitives.NewTransactionValidityError(primitives.NewInvalidTransactionPayment())
+			return invalidTransactionPayment
 		}
 
 		if alreadyPaidNegativeImbalance.Lt(refundPositiveImbalance) {
-			return primitives.NewTransactionValidityError(primitives.NewInvalidTransactionPayment())
+			// TODO https://github.com/LimeChain/gosemble/issues/271
+			invalidTransactionPayment, _ := primitives.NewTransactionValidityError(primitives.NewInvalidTransactionPayment())
+			return invalidTransactionPayment
 		}
 	}
 	return nil

--- a/frame/transaction_payment/extensions/charge_transaction_payment_test.go
+++ b/frame/transaction_payment/extensions/charge_transaction_payment_test.go
@@ -56,7 +56,7 @@ var (
 		},
 	}
 
-	invalidTransactionPaymentError = types.NewTransactionValidityError(types.NewInvalidTransactionPayment())
+	invalidTransactionPaymentError, _ = types.NewTransactionValidityError(types.NewInvalidTransactionPayment())
 )
 
 var (

--- a/frame/transaction_payment/extensions/charge_transaction_test.go
+++ b/frame/transaction_payment/extensions/charge_transaction_test.go
@@ -25,7 +25,7 @@ var (
 	alreadyWithdrawn = sc.NewOption[sc.U128](sc.NewU128(11))
 	refundAmount     = sc.NewU128(1)
 
-	expectedError = primitives.NewTransactionValidityError(primitives.NewInvalidTransactionPayment())
+	expectedError, _ = primitives.NewTransactionValidityError(primitives.NewInvalidTransactionPayment())
 )
 
 func Test_ChargeTransaction_WithdrawFee_Success(t *testing.T) {

--- a/frame/transaction_payment/module_test.go
+++ b/frame/transaction_payment/module_test.go
@@ -41,7 +41,7 @@ var (
 )
 
 var (
-	noUnsignedValidatorError = types.NewTransactionValidityError(
+	noUnsignedValidatorError, _ = types.NewTransactionValidityError(
 		types.NewUnknownTransactionNoUnsignedValidator(),
 	)
 

--- a/primitives/hashing/hashing.go
+++ b/primitives/hashing/hashing.go
@@ -23,10 +23,10 @@ func Blake2b8(data []byte) (digest [8]byte, err error) {
 }
 
 // MustBlake2b8 returns the first 8 bytes of the Blake2b hash of the input data
-func MustBlake2b8(data []byte) ([8]byte, error) {
+func MustBlake2b8(data []byte) [8]byte {
 	digest, err := Blake2b8(data)
 	if err != nil {
-		return *new([8]byte), err
+		panic(err)
 	}
-	return digest, nil
+	return digest
 }

--- a/primitives/hashing/hashing.go
+++ b/primitives/hashing/hashing.go
@@ -1,7 +1,6 @@
 package hashing
 
 import (
-	"github.com/LimeChain/gosemble/primitives/log"
 	"golang.org/x/crypto/blake2b"
 )
 
@@ -24,10 +23,10 @@ func Blake2b8(data []byte) (digest [8]byte, err error) {
 }
 
 // MustBlake2b8 returns the first 8 bytes of the Blake2b hash of the input data
-func MustBlake2b8(data []byte) [8]byte {
+func MustBlake2b8(data []byte) ([8]byte, error) {
 	digest, err := Blake2b8(data)
 	if err != nil {
-		log.Critical(err.Error())
+		return *new([8]byte), err
 	}
-	return digest
+	return digest, nil
 }

--- a/primitives/types/apply_extrinsic_result.go
+++ b/primitives/types/apply_extrinsic_result.go
@@ -27,17 +27,15 @@ import (
 //   - The extrinsic supplied a bad signature. This transaction won't become valid ever.
 type ApplyExtrinsicResult sc.VaryingData // = sc.Result[DispatchOutcome, TransactionValidityError]
 
-func NewApplyExtrinsicResult(value sc.Encodable) ApplyExtrinsicResult {
+func NewApplyExtrinsicResult(value sc.Encodable) (ApplyExtrinsicResult, error) {
 	// DispatchOutcome 					= 0 Outcome of dispatching the extrinsic.
 	// TransactionValidityError = 1 Possible errors while checking the validity of a transaction.
 	switch value.(type) {
 	case DispatchOutcome, TransactionValidityError:
-		return ApplyExtrinsicResult(sc.NewVaryingData(value))
+		return ApplyExtrinsicResult(sc.NewVaryingData(value)), nil
 	default:
-		log.Critical("invalid ApplyExtrinsicResult type")
+		return nil, NewTypeError("ApplyExtrinsicResult")
 	}
-
-	panic("unreachable")
 }
 
 func (r ApplyExtrinsicResult) Encode(buffer *bytes.Buffer) {
@@ -65,18 +63,16 @@ func DecodeApplyExtrinsicResult(buffer *bytes.Buffer) (ApplyExtrinsicResult, err
 		if err != nil {
 			return nil, err
 		}
-		return NewApplyExtrinsicResult(value), nil
+		return NewApplyExtrinsicResult(value)
 	case 1:
 		value, err := DecodeTransactionValidityError(buffer)
 		if err != nil {
 			return nil, err
 		}
-		return NewApplyExtrinsicResult(value), nil
+		return NewApplyExtrinsicResult(value)
 	default:
-		log.Critical("invalid ApplyExtrinsicResult type")
+		return nil, NewTypeError("ApplyExtrinsicResult")
 	}
-
-	panic("unreachable")
 }
 
 func (r ApplyExtrinsicResult) Bytes() []byte {

--- a/primitives/types/apply_extrinsic_result.go
+++ b/primitives/types/apply_extrinsic_result.go
@@ -34,7 +34,7 @@ func NewApplyExtrinsicResult(value sc.Encodable) (ApplyExtrinsicResult, error) {
 	case DispatchOutcome, TransactionValidityError:
 		return ApplyExtrinsicResult(sc.NewVaryingData(value)), nil
 	default:
-		return nil, NewTypeError("ApplyExtrinsicResult")
+		return nil, newTypeError("ApplyExtrinsicResult")
 	}
 }
 
@@ -71,7 +71,7 @@ func DecodeApplyExtrinsicResult(buffer *bytes.Buffer) (ApplyExtrinsicResult, err
 		}
 		return NewApplyExtrinsicResult(value)
 	default:
-		return nil, NewTypeError("ApplyExtrinsicResult")
+		return nil, newTypeError("ApplyExtrinsicResult")
 	}
 }
 

--- a/primitives/types/apply_extrinsic_result_test.go
+++ b/primitives/types/apply_extrinsic_result_test.go
@@ -7,6 +7,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var (
+	invalidTransactionCall, _ = NewTransactionValidityError(NewInvalidTransactionCall())
+
+	dispatchOutcome, _             = NewDispatchOutcome(nil)
+	dispatchOutcomeBadOriginErr, _ = NewDispatchOutcome(NewDispatchErrorBadOrigin())
+
+	applyExtrinsicResultOutcome, _      = NewApplyExtrinsicResult(dispatchOutcome)
+	applyExtrinsicResultBadOriginErr, _ = NewApplyExtrinsicResult(dispatchOutcomeBadOriginErr)
+	applyExtrinsicResultInvalidCall, _  = NewApplyExtrinsicResult(invalidTransactionCall)
+)
+
 func Test_EncodeApplyExtrinsicResult(t *testing.T) {
 	var testExamples = []struct {
 		label       string
@@ -15,17 +26,17 @@ func Test_EncodeApplyExtrinsicResult(t *testing.T) {
 	}{
 		{
 			label:       "Encode ApplyExtrinsicResult(NewDispatchOutcome(None))",
-			input:       NewApplyExtrinsicResult(NewDispatchOutcome(nil)),
+			input:       applyExtrinsicResultOutcome,
 			expectation: []byte{0x00, 0x00},
 		},
 		{
 			label:       "Encode ApplyExtrinsicResult(NewDispatchOutcome(NewDispatchErrorBadOrigin))",
-			input:       NewApplyExtrinsicResult(NewDispatchOutcome(NewDispatchErrorBadOrigin())),
+			input:       applyExtrinsicResultBadOriginErr,
 			expectation: []byte{0x00, 0x01, 0x02},
 		},
 		{
 			label:       "Encode ApplyExtrinsicResult(NewTransactionValidityError(NewInvalidTransactionCall))",
-			input:       NewApplyExtrinsicResult(NewTransactionValidityError(NewInvalidTransactionCall())),
+			input:       applyExtrinsicResultInvalidCall,
 			expectation: []byte{0x01, 0x00, 0x00},
 		},
 	}
@@ -49,17 +60,17 @@ func Test_DecodeApplyExtrinsicResult(t *testing.T) {
 	}{
 		{
 			label:       "Decode ApplyExtrinsicResult(NewDispatchOutcome(None))",
-			expectation: NewApplyExtrinsicResult(NewDispatchOutcome(nil)),
+			expectation: applyExtrinsicResultOutcome,
 			input:       []byte{0x00, 0x00},
 		},
 		{
 			label:       "Decode ApplyExtrinsicResult(NewDispatchOutcome(NewDispatchErrorBadOrigin))",
-			expectation: NewApplyExtrinsicResult(NewDispatchOutcome(NewDispatchErrorBadOrigin())),
+			expectation: applyExtrinsicResultBadOriginErr,
 			input:       []byte{0x00, 0x01, 0x02},
 		},
 		{
 			label:       "Decode ApplyExtrinsicResult(NewTransactionValidityError(NewInvalidTransactionCall)",
-			expectation: NewApplyExtrinsicResult(NewTransactionValidityError(NewInvalidTransactionCall())),
+			expectation: applyExtrinsicResultInvalidCall,
 			input:       []byte{0x01, 0x00, 0x00},
 		},
 	}

--- a/primitives/types/arithmetic_error.go
+++ b/primitives/types/arithmetic_error.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 
 	sc "github.com/LimeChain/goscale"
-	"github.com/LimeChain/gosemble/primitives/log"
 )
 
 const (
@@ -41,8 +40,6 @@ func DecodeArithmeticError(buffer *bytes.Buffer) (ArithmeticError, error) {
 	case ArithmeticErrorDivisionByZero:
 		return NewArithmeticErrorDivisionByZero(), nil
 	default:
-		log.Critical("invalid ArithmeticError type")
+		return nil, NewTypeError("ArithmeticError")
 	}
-
-	panic("unreachable")
 }

--- a/primitives/types/arithmetic_error.go
+++ b/primitives/types/arithmetic_error.go
@@ -40,6 +40,6 @@ func DecodeArithmeticError(buffer *bytes.Buffer) (ArithmeticError, error) {
 	case ArithmeticErrorDivisionByZero:
 		return NewArithmeticErrorDivisionByZero(), nil
 	default:
-		return nil, NewTypeError("ArithmeticError")
+		return nil, newTypeError("ArithmeticError")
 	}
 }

--- a/primitives/types/arithmetic_error_test.go
+++ b/primitives/types/arithmetic_error_test.go
@@ -47,10 +47,12 @@ func Test_ArithmeticError_Decode(t *testing.T) {
 	}
 }
 
-func Test_Decode_Panic(t *testing.T) {
+func Test_Decode_TypeError(t *testing.T) {
 	buffer := bytes.NewBuffer([]byte{0x03})
 
-	assert.PanicsWithValue(t, "invalid ArithmeticError type", func() {
-		DecodeArithmeticError(buffer)
-	})
+	res, err := DecodeArithmeticError(buffer)
+
+	assert.Error(t, err)
+	assert.Equal(t, "not a valid 'ArithmeticError' type", err.Error())
+	assert.Nil(t, res)
 }

--- a/primitives/types/block_weights.go
+++ b/primitives/types/block_weights.go
@@ -51,5 +51,5 @@ func (bw BlockWeights) Get(class DispatchClass) (*WeightsPerClass, error) {
 		return &bw.PerClass.Mandatory, nil
 	}
 
-	return nil, NewTypeError("DispatchClass")
+	return nil, newTypeError("DispatchClass")
 }

--- a/primitives/types/block_weights.go
+++ b/primitives/types/block_weights.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 
 	sc "github.com/LimeChain/goscale"
-	"github.com/LimeChain/gosemble/primitives/log"
 )
 
 type BlockWeights struct {
@@ -27,16 +26,30 @@ func (bw BlockWeights) Bytes() []byte {
 }
 
 // Get per-class weight settings.
-func (bw BlockWeights) Get(class DispatchClass) *WeightsPerClass {
-	if class.Is(DispatchClassNormal) {
-		return &bw.PerClass.Normal
-	} else if class.Is(DispatchClassOperational) {
-		return &bw.PerClass.Operational
-	} else if class.Is(DispatchClassMandatory) {
-		return &bw.PerClass.Mandatory
-	} else {
-		log.Critical("Invalid dispatch class")
+func (bw BlockWeights) Get(class DispatchClass) (*WeightsPerClass, error) {
+	isNormalDispatch, err := class.Is(DispatchClassNormal)
+	if err != nil {
+		return nil, err
+	}
+	if isNormalDispatch {
+		return &bw.PerClass.Normal, nil
 	}
 
-	panic("unreachable")
+	isOperationalDispatch, err := class.Is(DispatchClassOperational)
+	if err != nil {
+		return nil, err
+	}
+	if isOperationalDispatch {
+		return &bw.PerClass.Operational, nil
+	}
+
+	isMandatoryDispatch, err := class.Is(DispatchClassMandatory)
+	if err != nil {
+		return nil, err
+	}
+	if isMandatoryDispatch {
+		return &bw.PerClass.Mandatory, nil
+	}
+
+	return nil, NewTypeError("DispatchClass")
 }

--- a/primitives/types/block_weights_test.go
+++ b/primitives/types/block_weights_test.go
@@ -79,17 +79,20 @@ func Test_BlockWeights_Get(t *testing.T) {
 
 	for _, testExample := range testExamples {
 		t.Run(testExample.label, func(t *testing.T) {
-			result := targetBlockWeights.Get(testExample.input)
+			result, err := targetBlockWeights.Get(testExample.input)
 
+			assert.NoError(t, err)
 			assert.Equal(t, testExample.expectation, result.BaseExtrinsic)
 		})
 	}
 }
 
-func Test_BlockWeights_Get_Panics(t *testing.T) {
+func Test_BlockWeights_Get_TypeError(t *testing.T) {
 	unknownDispatchClass := DispatchClass{sc.NewVaryingData(sc.U8(3))}
 
-	assert.PanicsWithValue(t, "Invalid dispatch class", func() {
-		targetBlockWeights.Get(unknownDispatchClass)
-	})
+	res, err := targetBlockWeights.Get(unknownDispatchClass)
+
+	assert.Error(t, err)
+	assert.Equal(t, "not a valid 'DispatchClass' type", err.Error())
+	assert.Nil(t, res)
 }

--- a/primitives/types/check_inherents_error.go
+++ b/primitives/types/check_inherents_error.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	sc "github.com/LimeChain/goscale"
-	"github.com/LimeChain/gosemble/primitives/log"
 )
 
 type InherentError struct {
@@ -51,8 +50,6 @@ func (ie InherentError) Error() string {
 	case InherentErrorApplication:
 		return "Inherent error application"
 	default:
-		log.Critical("invalid inherent error")
+		return NewTypeError("InherentError").Error()
 	}
-
-	panic("unreachable")
 }

--- a/primitives/types/check_inherents_error.go
+++ b/primitives/types/check_inherents_error.go
@@ -50,6 +50,6 @@ func (ie InherentError) Error() string {
 	case InherentErrorApplication:
 		return "Inherent error application"
 	default:
-		return NewTypeError("InherentError").Error()
+		return newTypeError("InherentError").Error()
 	}
 }

--- a/primitives/types/check_inherents_error_test.go
+++ b/primitives/types/check_inherents_error_test.go
@@ -88,10 +88,10 @@ func Test_InherentError_Error_ErrorApplication(t *testing.T) {
 	)
 }
 
-func Test_InherentError_Error_Panics(t *testing.T) {
-	err := InherentError{sc.NewVaryingData(sc.U8(4))}
+func Test_InherentError_Error_TypeError(t *testing.T) {
+	inherentError := InherentError{sc.NewVaryingData(sc.U8(4))}
 
-	assert.PanicsWithValue(t, "invalid inherent error", func() {
-		_ = err.Error()
-	})
+	err := inherentError.Error()
+
+	assert.Equal(t, "not a valid 'InherentError' type", err)
 }

--- a/primitives/types/check_inherents_result.go
+++ b/primitives/types/check_inherents_result.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 
 	sc "github.com/LimeChain/goscale"
-	"github.com/LimeChain/gosemble/primitives/log"
 )
 
 const (
@@ -12,10 +11,6 @@ const (
 	InherentErrorDecodingFailed
 	InherentErrorFatalErrorReported
 	InherentErrorApplication
-)
-
-const (
-	errDecodeInherentData = "failed to decode InherentData"
 )
 
 type CheckInherentsResult struct {
@@ -73,7 +68,6 @@ func DecodeCheckInherentsResult(buffer *bytes.Buffer) (CheckInherentsResult, err
 	}
 	errors, err := DecodeInherentData(buffer)
 	if err != nil {
-		log.Critical(errDecodeInherentData)
 		return CheckInherentsResult{}, err
 	}
 

--- a/primitives/types/check_inherents_result_test.go
+++ b/primitives/types/check_inherents_result_test.go
@@ -3,6 +3,7 @@ package types
 import (
 	"bytes"
 	"encoding/hex"
+	"io"
 	"testing"
 
 	sc "github.com/LimeChain/goscale"
@@ -120,6 +121,6 @@ func Test_DecodeCheckInherentsResult_DecodeError(t *testing.T) {
 	result, err := DecodeCheckInherentsResult(buffer)
 
 	assert.Error(t, err)
-	assert.Equal(t, "EOF", err.Error())
+	assert.Equal(t, io.EOF, err)
 	assert.Equal(t, CheckInherentsResult{}, result)
 }

--- a/primitives/types/check_inherents_result_test.go
+++ b/primitives/types/check_inherents_result_test.go
@@ -93,7 +93,7 @@ func Test_CheckInherentsResult_PutError_AlreadyWithError(t *testing.T) {
 func Test_CheckInherentsResult_PutError(t *testing.T) {
 	err := targetCheckInherentsResultOk.PutError(inherentIdentifier, fatalError)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, sc.Bool(false), targetCheckInherentsResultOk.Okay)
 	assert.Equal(t, sc.Bool(true), targetCheckInherentsResultOk.FatalError)
 	assert.Equal(t, inherentDataErr, targetCheckInherentsResultOk.Errors)
@@ -114,11 +114,12 @@ func Test_DecodeCheckInherentsResult(t *testing.T) {
 	assert.Equal(t, targetCheckInherentsResultErr, result)
 }
 
-func Test_DecodeCheckInherentsResult_Panics(t *testing.T) {
+func Test_DecodeCheckInherentsResult_DecodeError(t *testing.T) {
 	buffer := bytes.NewBuffer(invalidCheckInherentsResultBytes)
 
-	assert.PanicsWithValue(t, "failed to decode InherentData", func() {
-		DecodeCheckInherentsResult(buffer)
-	})
+	result, err := DecodeCheckInherentsResult(buffer)
 
+	assert.Error(t, err)
+	assert.Equal(t, "EOF", err.Error())
+	assert.Equal(t, CheckInherentsResult{}, result)
 }

--- a/primitives/types/consumed_weight.go
+++ b/primitives/types/consumed_weight.go
@@ -47,7 +47,7 @@ func (cw *ConsumedWeight) Get(class DispatchClass) (*Weight, error) {
 	case DispatchClassMandatory:
 		return &cw.Mandatory, nil
 	default:
-		return nil, NewTypeError("DispatchClass")
+		return nil, newTypeError("DispatchClass")
 	}
 }
 

--- a/primitives/types/consumed_weight.go
+++ b/primitives/types/consumed_weight.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 
 	sc "github.com/LimeChain/goscale"
-	"github.com/LimeChain/gosemble/primitives/log"
 )
 
 // An object to track the currently used extrinsic weight in a block.
@@ -39,67 +38,83 @@ func (cw ConsumedWeight) Bytes() []byte {
 }
 
 // Get current value for given class.
-func (cw *ConsumedWeight) Get(class DispatchClass) *Weight {
+func (cw *ConsumedWeight) Get(class DispatchClass) (*Weight, error) {
 	switch class.VaryingData[0] {
 	case DispatchClassNormal:
-		return &cw.Normal
+		return &cw.Normal, nil
 	case DispatchClassOperational:
-		return &cw.Operational
+		return &cw.Operational, nil
 	case DispatchClassMandatory:
-		return &cw.Mandatory
+		return &cw.Mandatory, nil
 	default:
-		log.Critical("invalid DispatchClass type")
+		return nil, NewTypeError("DispatchClass")
 	}
-
-	panic("unreachable")
 }
 
 // Returns the total weight consumed by all extrinsics in the block.
 //
 // Saturates on overflow.
-func (cw ConsumedWeight) Total() Weight {
+func (cw ConsumedWeight) Total() (Weight, error) {
 	sum := WeightZero()
 	for _, class := range DispatchClassAll() {
-		sum = sum.SaturatingAdd(*cw.Get(class))
+		weightForClass, err := cw.Get(class)
+		if err != nil {
+			return Weight{}, err
+		}
+		sum = sum.SaturatingAdd(*weightForClass)
 	}
-	return sum
+	return sum, nil
 }
 
 // SaturatingAdd Increase the weight of the given class. Saturates at the numeric bounds.
-func (cw *ConsumedWeight) SaturatingAdd(weight Weight, class DispatchClass) {
-	weightForClass := cw.Get(class)
+func (cw *ConsumedWeight) SaturatingAdd(weight Weight, class DispatchClass) error {
+	weightForClass, err := cw.Get(class)
+	if err != nil {
+		return err
+	}
 	weightForClass.RefTime = sc.SaturatingAddU64(weightForClass.RefTime, weight.RefTime)
 	weightForClass.ProofSize = sc.SaturatingAddU64(weightForClass.ProofSize, weight.ProofSize)
+	return nil
 }
 
 // Accrue Increase the weight of the given class. Saturates at the numeric bounds.
-func (cw *ConsumedWeight) Accrue(weight Weight, class DispatchClass) {
-	weightForClass := cw.Get(class)
+func (cw *ConsumedWeight) Accrue(weight Weight, class DispatchClass) error {
+	weightForClass, err := cw.Get(class)
+	if err != nil {
+		return err
+	}
 	weightForClass.SaturatingAccrue(weight)
+	return nil
 }
 
 // CheckedAccrue Try to increase the weight of the given class. Saturates at the numeric bounds.
-func (cw *ConsumedWeight) CheckedAccrue(weight Weight, class DispatchClass) (sc.Empty, error) {
-	weightForClass := cw.Get(class)
-
+func (cw *ConsumedWeight) CheckedAccrue(weight Weight, class DispatchClass) error {
+	weightForClass, err := cw.Get(class)
+	if err != nil {
+		return err
+	}
 	refTime, err := sc.CheckedAddU64(weightForClass.RefTime, weight.RefTime)
 	if err != nil {
-		return sc.Empty{}, err
+		return err
 	}
 
 	proofSize, err := sc.CheckedAddU64(weightForClass.ProofSize, weight.ProofSize)
 	if err != nil {
-		return sc.Empty{}, err
+		return err
 	}
 
 	weightForClass.RefTime = refTime
 	weightForClass.ProofSize = proofSize
 
-	return sc.Empty{}, nil
+	return nil
 }
 
 // Reduce the weight of the given class. Saturates at the numeric bounds.
-func (cw *ConsumedWeight) Reduce(weight Weight, class DispatchClass) {
-	weightForClass := cw.Get(class)
+func (cw *ConsumedWeight) Reduce(weight Weight, class DispatchClass) error {
+	weightForClass, err := cw.Get(class)
+	if err != nil {
+		return err
+	}
 	weightForClass.SaturatingReduce(weight)
+	return nil
 }

--- a/primitives/types/consumed_weight_test.go
+++ b/primitives/types/consumed_weight_test.go
@@ -33,7 +33,7 @@ func Test_DecodeConsumedWeight(t *testing.T) {
 	buf := bytes.NewBuffer(expectedConsumedWeightBytes)
 
 	result, err := DecodeConsumedWeight(buf)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, targetConsumedWeight, result)
 }
 
@@ -42,39 +42,41 @@ func Test_ConsumedWeight_Bytes(t *testing.T) {
 }
 
 func Test_ConsumedWeight_Get_Normal(t *testing.T) {
-	assert.Equal(t,
-		WeightFromParts(1, 2),
-		*targetConsumedWeight.Get(NewDispatchClassNormal()),
-	)
+	result, err := targetConsumedWeight.Get(NewDispatchClassNormal())
+
+	assert.NoError(t, err)
+	assert.Equal(t, WeightFromParts(1, 2), *result)
 }
 
 func Test_ConsumedWeight_Get_Operational(t *testing.T) {
-	assert.Equal(t,
-		WeightFromParts(3, 4),
-		*targetConsumedWeight.Get(NewDispatchClassOperational()),
-	)
+	result, err := targetConsumedWeight.Get(NewDispatchClassOperational())
+
+	assert.NoError(t, err)
+	assert.Equal(t, WeightFromParts(3, 4), *result)
 }
 
 func Test_ConsumedWeight_Get_Mandatory(t *testing.T) {
-	assert.Equal(t,
-		WeightFromParts(5, 6),
-		*targetConsumedWeight.Get(NewDispatchClassMandatory()),
-	)
+	result, err := targetConsumedWeight.Get(NewDispatchClassMandatory())
+
+	assert.NoError(t, err)
+	assert.Equal(t, WeightFromParts(5, 6), *result)
 }
 
 func Test_ConsumedWeight_Get_UnknownPanics(t *testing.T) {
 	unknownDispatchClass := DispatchClass{sc.NewVaryingData(sc.U8(3))}
 
-	assert.PanicsWithValue(t, "invalid DispatchClass type", func() {
-		targetConsumedWeight.Get(unknownDispatchClass)
-	})
+	result, err := targetConsumedWeight.Get(unknownDispatchClass)
+
+	assert.Error(t, err)
+	assert.Equal(t, "not a valid 'DispatchClass' type", err.Error())
+	assert.Nil(t, result)
 }
 
 func Test_ConsumedWeight_Total(t *testing.T) {
-	assert.Equal(t,
-		WeightFromParts(9, 12),
-		targetConsumedWeight.Total(),
-	)
+	result, err := targetConsumedWeight.Total()
+
+	assert.NoError(t, err)
+	assert.Equal(t, WeightFromParts(9, 12), result)
 }
 
 func Test_ConsumedWeight_SaturatingAdd(t *testing.T) {
@@ -83,20 +85,17 @@ func Test_ConsumedWeight_SaturatingAdd(t *testing.T) {
 		NewDispatchClassNormal(),
 	)
 
-	assert.Equal(t,
-		WeightFromParts(math.MaxUint64, math.MaxUint64),
-		*targetConsumedWeight.Get(NewDispatchClassNormal()),
-	)
+	consumedWeightNormal, err := targetConsumedWeight.Get(NewDispatchClassNormal())
+	assert.NoError(t, err)
+	assert.Equal(t, WeightFromParts(math.MaxUint64, math.MaxUint64), *consumedWeightNormal)
 
-	assert.Equal(t,
-		WeightFromParts(3, 4),
-		*targetConsumedWeight.Get(NewDispatchClassOperational()),
-	)
+	consumedWeightOperational, err := targetConsumedWeight.Get(NewDispatchClassOperational())
+	assert.NoError(t, err)
+	assert.Equal(t, WeightFromParts(3, 4), *consumedWeightOperational)
 
-	assert.Equal(t,
-		WeightFromParts(5, 6),
-		*targetConsumedWeight.Get(NewDispatchClassMandatory()),
-	)
+	consumedWeightMandatory, err := targetConsumedWeight.Get(NewDispatchClassMandatory())
+	assert.NoError(t, err)
+	assert.Equal(t, WeightFromParts(5, 6), *consumedWeightMandatory)
 }
 
 func Test_ConsumedWeight_Accrue(t *testing.T) {
@@ -134,11 +133,11 @@ func Test_ConsumedWeight_CheckedAccrue_Ok(t *testing.T) {
 		Mandatory:   WeightFromParts(5, 6),
 	}
 
-	_, err := targetConsumedWeight.CheckedAccrue(
+	err := targetConsumedWeight.CheckedAccrue(
 		WeightFromParts(1, 1),
 		NewDispatchClassNormal(),
 	)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t,
 		WeightFromParts(2, 3),
@@ -163,7 +162,7 @@ func Test_ConsumedWeight_CheckedAccrue_RefTimeOverflow(t *testing.T) {
 		Mandatory:   WeightFromParts(5, 6),
 	}
 
-	_, err := targetConsumedWeight.CheckedAccrue(
+	err := targetConsumedWeight.CheckedAccrue(
 		WeightFromParts(math.MaxUint64, 1),
 		NewDispatchClassNormal(),
 	)
@@ -192,13 +191,13 @@ func Test_ConsumedWeight_CheckedAccrue_ProofSizeOverflow(t *testing.T) {
 		Mandatory:   WeightFromParts(5, 6),
 	}
 
-	_, err := targetConsumedWeight.CheckedAccrue(
+	err := targetConsumedWeight.CheckedAccrue(
 		WeightFromParts(1, math.MaxUint64),
 		NewDispatchClassNormal(),
 	)
 	assert.Equal(t, errors.New("overflow"), err)
 
-	_, err = targetConsumedWeight.CheckedAccrue(
+	err = targetConsumedWeight.CheckedAccrue(
 		WeightFromParts(math.MaxUint64, 1),
 		NewDispatchClassNormal(),
 	)

--- a/primitives/types/dispatch_class.go
+++ b/primitives/types/dispatch_class.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 
 	sc "github.com/LimeChain/goscale"
-	"github.com/LimeChain/gosemble/primitives/log"
 )
 
 const (
@@ -61,22 +60,18 @@ func DecodeDispatchClass(buffer *bytes.Buffer) (DispatchClass, error) {
 	case DispatchClassMandatory:
 		return NewDispatchClassMandatory(), nil
 	default:
-		log.Critical("invalid DispatchClass type")
+		return DispatchClass{}, NewTypeError("DispatchClass")
 	}
-
-	panic("unreachable")
 }
 
-func (dc DispatchClass) Is(value sc.U8) sc.Bool {
+func (dc DispatchClass) Is(value sc.U8) (sc.Bool, error) {
 	// TODO: type safety
 	switch value {
 	case DispatchClassNormal, DispatchClassOperational, DispatchClassMandatory:
-		return dc.VaryingData[0] == value
+		return (dc.VaryingData[0] == value), nil
 	default:
-		log.Critical("invalid DispatchClass value")
+		return false, NewTypeError("DispatchClass")
 	}
-
-	panic("unreachable")
 }
 
 // Returns an array containing all dispatch classes.

--- a/primitives/types/dispatch_class.go
+++ b/primitives/types/dispatch_class.go
@@ -60,7 +60,7 @@ func DecodeDispatchClass(buffer *bytes.Buffer) (DispatchClass, error) {
 	case DispatchClassMandatory:
 		return NewDispatchClassMandatory(), nil
 	default:
-		return DispatchClass{}, NewTypeError("DispatchClass")
+		return DispatchClass{}, newTypeError("DispatchClass")
 	}
 }
 
@@ -70,7 +70,7 @@ func (dc DispatchClass) Is(value sc.U8) (sc.Bool, error) {
 	case DispatchClassNormal, DispatchClassOperational, DispatchClassMandatory:
 		return (dc.VaryingData[0] == value), nil
 	default:
-		return false, NewTypeError("DispatchClass")
+		return false, newTypeError("DispatchClass")
 	}
 }
 

--- a/primitives/types/dispatch_class_test.go
+++ b/primitives/types/dispatch_class_test.go
@@ -62,30 +62,33 @@ func Test_DecodeDispatchClass_Mandatory(t *testing.T) {
 	assert.Equal(t, targetDispatchClass, dispatchClass)
 }
 
-func Test_DecodeDispatchClass_Panic(t *testing.T) {
-	targetDispatchClass := DispatchClass{sc.NewVaryingData(sc.U8(3))}
-
+func Test_DecodeDispatchClass_TypeError(t *testing.T) {
 	buf := &bytes.Buffer{}
+	targetDispatchClass := DispatchClass{sc.NewVaryingData(sc.U8(3))}
 	targetDispatchClass.Encode(buf)
 
-	assert.PanicsWithValue(t, "invalid DispatchClass type", func() {
-		DecodeDispatchClass(buf)
-	})
+	result, err := DecodeDispatchClass(buf)
+
+	assert.Error(t, err)
+	assert.Equal(t, "not a valid 'DispatchClass' type", err.Error())
+	assert.Equal(t, DispatchClass{}, result)
 }
 
-func Test_Is(t *testing.T) {
-	assert.Equal(t,
-		sc.Bool(true),
-		NewDispatchClassNormal().Is(DispatchClassNormal),
-	)
+func Test_DispatchClass_Is(t *testing.T) {
+	result, err := NewDispatchClassNormal().Is(DispatchClassNormal)
+
+	assert.NoError(t, err)
+	assert.Equal(t, sc.Bool(true), result)
 }
 
-func Test_Is_Panic(t *testing.T) {
+func Test_DispatchClass_Is_TypeError(t *testing.T) {
 	unknownDispatchClass := sc.U8(3)
 
-	assert.PanicsWithValue(t, "invalid DispatchClass value", func() {
-		NewDispatchClassNormal().Is(unknownDispatchClass)
-	})
+	result, err := NewDispatchClassNormal().Is(unknownDispatchClass)
+
+	assert.Error(t, err)
+	assert.Equal(t, "not a valid 'DispatchClass' type", err.Error())
+	assert.Equal(t, sc.Bool(false), result)
 }
 
 func Test_DispatchClassAll(t *testing.T) {

--- a/primitives/types/dispatch_errors.go
+++ b/primitives/types/dispatch_errors.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 
 	sc "github.com/LimeChain/goscale"
-	"github.com/LimeChain/gosemble/primitives/log"
 )
 
 const (
@@ -134,10 +133,8 @@ func DecodeDispatchError(buffer *bytes.Buffer) (DispatchError, error) {
 	case DispatchErrorUnavailable:
 		return NewDispatchErrorUnavailable(), nil
 	default:
-		log.Critical("invalid DispatchError type")
+		return DispatchError{}, NewTypeError("DispatchError")
 	}
-
-	panic("unreachable")
 }
 
 // CustomModuleError A custom error in a module.

--- a/primitives/types/dispatch_errors.go
+++ b/primitives/types/dispatch_errors.go
@@ -133,7 +133,7 @@ func DecodeDispatchError(buffer *bytes.Buffer) (DispatchError, error) {
 	case DispatchErrorUnavailable:
 		return NewDispatchErrorUnavailable(), nil
 	default:
-		return DispatchError{}, NewTypeError("DispatchError")
+		return DispatchError{}, newTypeError("DispatchError")
 	}
 }
 

--- a/primitives/types/dispatch_outcome.go
+++ b/primitives/types/dispatch_outcome.go
@@ -30,7 +30,7 @@ func NewDispatchOutcome(value sc.Encodable) (DispatchOutcome, error) {
 	case sc.Empty, nil:
 		return DispatchOutcome(sc.NewVaryingData(sc.Empty{})), nil
 	default:
-		return DispatchOutcome{}, NewTypeError("DispatchOutcome")
+		return DispatchOutcome{}, newTypeError("DispatchOutcome")
 	}
 }
 
@@ -64,7 +64,7 @@ func DecodeDispatchOutcome(buffer *bytes.Buffer) (DispatchOutcome, error) {
 		}
 		return NewDispatchOutcome(value)
 	default:
-		return DispatchOutcome{}, NewTypeError("DispatchOutcome")
+		return DispatchOutcome{}, newTypeError("DispatchOutcome")
 	}
 }
 

--- a/primitives/types/dispatch_outcome_test.go
+++ b/primitives/types/dispatch_outcome_test.go
@@ -8,10 +8,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_DispatchOutcome_New_Panics(t *testing.T) {
-	assert.PanicsWithValue(t, errDispatchOutcomeInvalid, func() {
-		NewDispatchOutcome(sc.U8(5))
-	})
+func Test_DispatchOutcome_New_TypeError(t *testing.T) {
+	result, err := NewDispatchOutcome(sc.U8(5))
+
+	assert.Error(t, err)
+	assert.Equal(t, "not a valid 'DispatchOutcome' type", err.Error())
+	assert.Equal(t, DispatchOutcome{}, result)
 }
 
 func Test_DispatchOutcome_Encode(t *testing.T) {
@@ -20,8 +22,8 @@ func Test_DispatchOutcome_Encode(t *testing.T) {
 		input       DispatchOutcome
 		expectation []byte
 	}{
-		{label: "Encode DispatchOutcome(None)", input: NewDispatchOutcome(nil), expectation: []byte{0x00}},
-		{label: "Encode  DispatchOutcome(DispatchErrorBadOrigin)", input: NewDispatchOutcome(NewDispatchErrorBadOrigin()), expectation: []byte{0x01, 0x02}},
+		{label: "Encode DispatchOutcome(None)", input: dispatchOutcome, expectation: []byte{0x00}},
+		{label: "Encode  DispatchOutcome(DispatchErrorBadOrigin)", input: dispatchOutcomeBadOriginErr, expectation: []byte{0x01, 0x02}},
 	}
 
 	for _, testExample := range testExamples {
@@ -52,8 +54,8 @@ func Test_DispatchOutcome_Bytes(t *testing.T) {
 		input  DispatchOutcome
 		expect []byte
 	}{
-		{label: "Encode DispatchOutcome(None)", input: NewDispatchOutcome(nil), expect: []byte{0x00}},
-		{label: "Encode  DispatchOutcome(DispatchErrorBadOrigin)", input: NewDispatchOutcome(NewDispatchErrorBadOrigin()), expect: []byte{0x01, 0x02}},
+		{label: "Encode DispatchOutcome(None)", input: dispatchOutcome, expect: []byte{0x00}},
+		{label: "Encode  DispatchOutcome(DispatchErrorBadOrigin)", input: dispatchOutcomeBadOriginErr, expect: []byte{0x01, 0x02}},
 	}
 
 	for _, testExample := range testExamples {
@@ -71,8 +73,8 @@ func Test_DispatchOutcome_Decode(t *testing.T) {
 		input       []byte
 		expectation DispatchOutcome
 	}{
-		{label: "0x00", input: []byte{0x00}, expectation: NewDispatchOutcome(nil)},
-		{label: "0x01, 0x02", input: []byte{0x01, 0x02}, expectation: NewDispatchOutcome(NewDispatchErrorBadOrigin())},
+		{label: "0x00", input: []byte{0x00}, expectation: dispatchOutcome},
+		{label: "0x01, 0x02", input: []byte{0x01, 0x02}, expectation: dispatchOutcomeBadOriginErr},
 	}
 
 	for _, testExample := range testExamples {
@@ -88,10 +90,12 @@ func Test_DispatchOutcome_Decode(t *testing.T) {
 	}
 }
 
-func Test_DispatchOutcome_Decode_Panics(t *testing.T) {
+func Test_DispatchOutcome_Decode_TypeError(t *testing.T) {
 	buffer := bytes.NewBuffer([]byte{0x3})
 
-	assert.PanicsWithValue(t, errDispatchOutcomeInvalid, func() {
-		DecodeDispatchOutcome(buffer)
-	})
+	result, err := DecodeDispatchOutcome(buffer)
+
+	assert.Error(t, err)
+	assert.Equal(t, "not a valid 'DispatchOutcome' type", err.Error())
+	assert.Equal(t, DispatchOutcome{}, result)
 }

--- a/primitives/types/dispatch_result.go
+++ b/primitives/types/dispatch_result.go
@@ -13,6 +13,6 @@ func NewDispatchResult(value sc.Encodable) (DispatchResult, error) {
 	case sc.Empty, nil:
 		return DispatchResult(sc.NewVaryingData(sc.Empty{})), nil
 	default:
-		return DispatchResult{}, NewTypeError("DispatchResult")
+		return DispatchResult{}, newTypeError("DispatchResult")
 	}
 }

--- a/primitives/types/dispatch_result.go
+++ b/primitives/types/dispatch_result.go
@@ -2,20 +2,17 @@ package types
 
 import (
 	sc "github.com/LimeChain/goscale"
-	"github.com/LimeChain/gosemble/primitives/log"
 )
 
 type DispatchResult sc.VaryingData
 
-func NewDispatchResult(value sc.Encodable) DispatchResult {
+func NewDispatchResult(value sc.Encodable) (DispatchResult, error) {
 	switch value.(type) {
 	case DispatchError, DispatchErrorWithPostInfo[PostDispatchInfo]:
-		return DispatchResult(sc.NewVaryingData(value))
+		return DispatchResult(sc.NewVaryingData(value)), nil
 	case sc.Empty, nil:
-		return DispatchResult(sc.NewVaryingData(sc.Empty{}))
+		return DispatchResult(sc.NewVaryingData(sc.Empty{})), nil
 	default:
-		log.Critical("invalid DispatchResult type")
+		return DispatchResult{}, NewTypeError("DispatchResult")
 	}
-
-	panic("unreachable")
 }

--- a/primitives/types/dispatch_result_test.go
+++ b/primitives/types/dispatch_result_test.go
@@ -51,13 +51,18 @@ func Test_NewDispatchResult_DispatchError(t *testing.T) {
 
 	for _, testExample := range testExamples {
 		t.Run(testExample.label, func(t *testing.T) {
-			assert.Equal(t, testExample.expectation, NewDispatchResult(testExample.input))
+			result, err := NewDispatchResult(testExample.input)
+
+			assert.NoError(t, err)
+			assert.Equal(t, testExample.expectation, result)
 		})
 	}
 }
 
-func Test_NewDispatchResult_DispatchError_Panic(t *testing.T) {
-	assert.PanicsWithValue(t, "invalid DispatchResult type", func() {
-		NewDispatchResult(sc.U8(0))
-	})
+func Test_NewDispatchResult_DispatchError_TypeError(t *testing.T) {
+	result, err := NewDispatchResult(sc.U8(0))
+
+	assert.Error(t, err)
+	assert.Equal(t, "not a valid 'DispatchResult' type", err.Error())
+	assert.Equal(t, DispatchResult{}, result)
 }

--- a/primitives/types/era.go
+++ b/primitives/types/era.go
@@ -8,7 +8,6 @@ import (
 
 	sc "github.com/LimeChain/goscale"
 	"github.com/LimeChain/gosemble/constants/metadata"
-	"github.com/LimeChain/gosemble/primitives/log"
 )
 
 // Era An era to describe the longevity of a transaction.
@@ -93,11 +92,9 @@ func DecodeEra(buffer *bytes.Buffer) (Era, error) {
 		if period >= 4 && phase < period {
 			return NewMortalEra(period, phase), nil
 		} else {
-			log.Critical("invalid period and phase")
+			return Era{}, NewTypeError("Era")
 		}
 	}
-
-	panic("unreachable")
 }
 
 func (e Era) Bytes() []byte {

--- a/primitives/types/era.go
+++ b/primitives/types/era.go
@@ -92,7 +92,7 @@ func DecodeEra(buffer *bytes.Buffer) (Era, error) {
 		if period >= 4 && phase < period {
 			return NewMortalEra(period, phase), nil
 		} else {
-			return Era{}, NewTypeError("Era")
+			return Era{}, newTypeError("Era")
 		}
 	}
 }

--- a/primitives/types/errors.go
+++ b/primitives/types/errors.go
@@ -1,0 +1,15 @@
+package types
+
+// typeError is a custom type error specific to
+// the Runtime and expected to be returned to the Host
+type typeError struct {
+	message string
+}
+
+func NewTypeError(msg string) error {
+	return typeError{message: msg}
+}
+
+func (e typeError) Error() string {
+	return "not a valid '" + e.message + "' type"
+}

--- a/primitives/types/errors.go
+++ b/primitives/types/errors.go
@@ -6,7 +6,7 @@ type typeError struct {
 	message string
 }
 
-func NewTypeError(msg string) error {
+func newTypeError(msg string) error {
 	return typeError{message: msg}
 }
 

--- a/primitives/types/extra_test.go
+++ b/primitives/types/extra_test.go
@@ -21,9 +21,7 @@ var (
 		Propagate: true,
 	}
 
-	expectedTransactionValidityError = NewTransactionValidityError(
-		NewUnknownTransactionCustomUnknownTransaction(sc.U8(0)),
-	)
+	expectedTransactionValidityError, _ = NewTransactionValidityError(NewUnknownTransactionCustomUnknownTransaction(sc.U8(0)))
 
 	testExtraCheckMetadataType = MetadataType{
 		Id:         sc.ToCompact(123456),

--- a/primitives/types/extrinsic_phase.go
+++ b/primitives/types/extrinsic_phase.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 
 	sc "github.com/LimeChain/goscale"
-	"github.com/LimeChain/gosemble/primitives/log"
 )
 
 const (
@@ -50,8 +49,6 @@ func DecodeExtrinsicPhase(buffer *bytes.Buffer) (ExtrinsicPhase, error) {
 	case PhaseInitialization:
 		return NewExtrinsicPhaseInitialization(), nil
 	default:
-		log.Critical("invalid ExtrinsicPhase type")
+		return ExtrinsicPhase{}, NewTypeError("ExtrinsicPhase")
 	}
-
-	panic("unreachable")
 }

--- a/primitives/types/extrinsic_phase.go
+++ b/primitives/types/extrinsic_phase.go
@@ -49,6 +49,6 @@ func DecodeExtrinsicPhase(buffer *bytes.Buffer) (ExtrinsicPhase, error) {
 	case PhaseInitialization:
 		return NewExtrinsicPhaseInitialization(), nil
 	default:
-		return ExtrinsicPhase{}, NewTypeError("ExtrinsicPhase")
+		return ExtrinsicPhase{}, newTypeError("ExtrinsicPhase")
 	}
 }

--- a/primitives/types/extrinsic_phase_test.go
+++ b/primitives/types/extrinsic_phase_test.go
@@ -35,7 +35,7 @@ func Test_DecodeExtrinsicPhase_ApplyExtrinsic(t *testing.T) {
 	buffer.Write(index.Bytes())
 
 	result, err := DecodeExtrinsicPhase(buffer)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, NewExtrinsicPhaseApply(index), result)
 }
@@ -45,7 +45,7 @@ func Test_DecodeExtrinsicPhase_Finalization(t *testing.T) {
 	buffer.WriteByte(1)
 
 	result, err := DecodeExtrinsicPhase(buffer)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, NewExtrinsicPhaseFinalization(), result)
 }
@@ -55,16 +55,18 @@ func Test_DecodeExtrinsicPhase_Initialization(t *testing.T) {
 	buffer.WriteByte(2)
 
 	result, err := DecodeExtrinsicPhase(buffer)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, NewExtrinsicPhaseInitialization(), result)
 }
 
-func Test_DecodeExtrinsicPhase_Panics(t *testing.T) {
+func Test_DecodeExtrinsicPhase_TypeError(t *testing.T) {
 	buffer := &bytes.Buffer{}
 	buffer.WriteByte(3)
 
-	assert.PanicsWithValue(t, "invalid ExtrinsicPhase type", func() {
-		DecodeExtrinsicPhase(buffer)
-	})
+	res, err := DecodeExtrinsicPhase(buffer)
+
+	assert.Error(t, err)
+	assert.Equal(t, "not a valid 'ExtrinsicPhase' type", err.Error())
+	assert.Equal(t, ExtrinsicPhase{}, res)
 }

--- a/primitives/types/extrinsic_signature_payload_test.go
+++ b/primitives/types/extrinsic_signature_payload_test.go
@@ -14,7 +14,7 @@ var (
 
 	expectedAdditionalSigned = sc.NewVaryingData(sc.U32(1))
 
-	expectedTransactionValidityErr = NewTransactionValidityError(NewUnknownTransactionCustomUnknownTransaction(sc.U8(0)))
+	expectedTransactionValidityErr, _ = NewTransactionValidityError(NewUnknownTransactionCustomUnknownTransaction(sc.U8(0)))
 )
 
 var (

--- a/primitives/types/extrinsic_signature_test.go
+++ b/primitives/types/extrinsic_signature_test.go
@@ -19,11 +19,8 @@ var (
 	signerAddressBytes = []byte{
 		1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
 	}
-	signer = NewMultiAddressId(
-		AccountId{
-			Address32: NewAddress32(sc.BytesToSequenceU8(signerAddressBytes)...),
-		},
-	)
+	addr32, _ = NewAddress32(sc.BytesToSequenceU8(signerAddressBytes)...)
+	signer    = NewMultiAddressId(AccountId{Address32: addr32})
 
 	signatureBytes = []byte{
 		2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
@@ -72,7 +69,7 @@ func Test_DecodeExtrinsicSignature(t *testing.T) {
 	)
 
 	result, err := DecodeExtrinsicSignature(signedExtraTemplate, buffer)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, targetExtrinsicSignature, result)
 }

--- a/primitives/types/hash_256.go
+++ b/primitives/types/hash_256.go
@@ -2,20 +2,20 @@ package types
 
 import (
 	"bytes"
+	"errors"
 
 	sc "github.com/LimeChain/goscale"
-	"github.com/LimeChain/gosemble/primitives/log"
 )
 
 type H256 struct {
 	sc.FixedSequence[sc.U8] // size 32
 }
 
-func NewH256(values ...sc.U8) H256 {
+func NewH256(values ...sc.U8) (H256, error) {
 	if len(values) != 32 {
-		log.Critical("H256 should be of size 32")
+		return H256{}, errors.New("H256 should be of size 32")
 	}
-	return H256{sc.NewFixedSequence(32, values...)}
+	return H256{sc.NewFixedSequence(32, values...)}, nil
 }
 
 func (h H256) Encode(buffer *bytes.Buffer) {

--- a/primitives/types/hash_256_test.go
+++ b/primitives/types/hash_256_test.go
@@ -18,15 +18,18 @@ var (
 )
 
 func Test_NewHash256(t *testing.T) {
-	result := NewH256(hash256Sequence...)
+	result, err := NewH256(hash256Sequence...)
 
+	assert.NoError(t, err)
 	assert.Equal(t, expectedH256Hash, result)
 }
 
 func Test_NewHash256_InvalidLength(t *testing.T) {
-	assert.PanicsWithValue(t, "H256 should be of size 32", func() {
-		NewH256(hash256Sequence[1:32]...)
-	})
+	result, err := NewH256(hash256Sequence[1:32]...)
+
+	assert.Error(t, err)
+	assert.Equal(t, "H256 should be of size 32", err.Error())
+	assert.Equal(t, H256{}, result)
 }
 
 func Test_Hash256_Encode(t *testing.T) {
@@ -39,7 +42,7 @@ func Test_Hash256_Encode(t *testing.T) {
 func Test_Hash256_Decode(t *testing.T) {
 	buffer := bytes.NewBuffer(sc.FixedSequenceU8ToBytes(hash256Sequence))
 	result, err := DecodeH256(buffer)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, expectedH256Hash, result)
 }

--- a/primitives/types/hash_512.go
+++ b/primitives/types/hash_512.go
@@ -2,20 +2,20 @@ package types
 
 import (
 	"bytes"
+	"errors"
 
 	sc "github.com/LimeChain/goscale"
-	"github.com/LimeChain/gosemble/primitives/log"
 )
 
 type H512 struct {
 	sc.FixedSequence[sc.U8] // size 64
 }
 
-func NewH512(values ...sc.U8) H512 {
+func NewH512(values ...sc.U8) (H512, error) {
 	if len(values) != 64 {
-		log.Critical("H512 should be of size 64")
+		return H512{}, errors.New("H512 should be of size 64")
 	}
-	return H512{sc.NewFixedSequence(64, values...)}
+	return H512{sc.NewFixedSequence(64, values...)}, nil
 }
 
 func (h H512) Encode(buffer *bytes.Buffer) {

--- a/primitives/types/hash_512_test.go
+++ b/primitives/types/hash_512_test.go
@@ -15,15 +15,18 @@ var (
 )
 
 func Test_NewHash512(t *testing.T) {
-	result := NewH512(hash512Sequence...)
+	result, err := NewH512(hash512Sequence...)
 
+	assert.NoError(t, err)
 	assert.Equal(t, expectedH512Hash, result)
 }
 
 func Test_NewHash512_InvalidLength(t *testing.T) {
-	assert.PanicsWithValue(t, "H512 should be of size 64", func() {
-		NewH512(hash512Sequence[1:63]...)
-	})
+	result, err := NewH512(hash512Sequence[1:63]...)
+
+	assert.Error(t, err)
+	assert.Equal(t, "H512 should be of size 64", err.Error())
+	assert.Equal(t, H512{}, result)
 }
 
 func Test_Hash512_Encode(t *testing.T) {
@@ -36,7 +39,7 @@ func Test_Hash512_Encode(t *testing.T) {
 func Test_Hash512_Decode(t *testing.T) {
 	buffer := bytes.NewBuffer(sc.FixedSequenceU8ToBytes(hash512Sequence))
 	result, err := DecodeH512(buffer)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, expectedH512Hash, result)
 }

--- a/primitives/types/hash_blake2b.go
+++ b/primitives/types/hash_blake2b.go
@@ -2,20 +2,20 @@ package types
 
 import (
 	"bytes"
+	"errors"
 
 	sc "github.com/LimeChain/goscale"
-	"github.com/LimeChain/gosemble/primitives/log"
 )
 
 type Blake2bHash struct {
 	sc.FixedSequence[sc.U8] // size 32
 }
 
-func NewBlake2bHash(values ...sc.U8) Blake2bHash {
+func NewBlake2bHash(values ...sc.U8) (Blake2bHash, error) {
 	if len(values) != 32 {
-		log.Critical("Blake2bHash should be of size 32")
+		return Blake2bHash{}, errors.New("Blake2bHash should be of size 32")
 	}
-	return Blake2bHash{sc.NewFixedSequence(32, values...)}
+	return Blake2bHash{sc.NewFixedSequence(32, values...)}, nil
 }
 
 func (h Blake2bHash) Encode(buffer *bytes.Buffer) {

--- a/primitives/types/hash_blake2b_test.go
+++ b/primitives/types/hash_blake2b_test.go
@@ -18,15 +18,18 @@ var (
 )
 
 func Test_NewBlake2bHash(t *testing.T) {
-	result := NewBlake2bHash(blake2bHashSequence...)
+	result, err := NewBlake2bHash(blake2bHashSequence...)
 
+	assert.NoError(t, err)
 	assert.Equal(t, expectedBlake2bHash, result)
 }
 
 func Test_NewBlake2bHash_InvalidLength(t *testing.T) {
-	assert.PanicsWithValue(t, "Blake2bHash should be of size 32", func() {
-		NewBlake2bHash(blake2bHashSequence[1:32]...)
-	})
+	result, err := NewBlake2bHash(blake2bHashSequence[1:32]...)
+
+	assert.Error(t, err)
+	assert.Equal(t, "Blake2bHash should be of size 32", err.Error())
+	assert.Equal(t, Blake2bHash{}, result)
 }
 
 func Test_Blake2bHash_Encode(t *testing.T) {
@@ -39,7 +42,7 @@ func Test_Blake2bHash_Encode(t *testing.T) {
 func Test_Blake2bHash_Decode(t *testing.T) {
 	buffer := bytes.NewBuffer(sc.FixedSequenceU8ToBytes(blake2bHashSequence))
 	result, err := DecodeBlake2bHash(buffer)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, expectedBlake2bHash, result)
 }

--- a/primitives/types/header_test.go
+++ b/primitives/types/header_test.go
@@ -25,11 +25,15 @@ var (
 		},
 	}
 
+	stateRootHash, _      = NewH256(sc.BytesToFixedSequenceU8(stateRoot.ToBytes())...)
+	extrinsicsRootHash, _ = NewH256(sc.BytesToFixedSequenceU8(extrinsicsRoot.ToBytes())...)
+	parentHeaderHash, _   = NewBlake2bHash(sc.BytesToFixedSequenceU8(parentHash.ToBytes())...)
+
 	targetHeader = Header{
-		ParentHash:     NewBlake2bHash(sc.BytesToFixedSequenceU8(parentHash.ToBytes())...),
+		ParentHash:     parentHeaderHash,
 		Number:         1,
-		StateRoot:      NewH256(sc.BytesToFixedSequenceU8(stateRoot.ToBytes())...),
-		ExtrinsicsRoot: NewH256(sc.BytesToFixedSequenceU8(extrinsicsRoot.ToBytes())...),
+		StateRoot:      stateRootHash,
+		ExtrinsicsRoot: extrinsicsRootHash,
 		Digest:         digest,
 	}
 )
@@ -46,7 +50,7 @@ func Test_Header_Decode(t *testing.T) {
 	buf := bytes.NewBuffer(expectBytesHeader)
 
 	result, err := DecodeHeader(buf)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, targetHeader.ParentHash, result.ParentHash)
 	assert.Equal(t, targetHeader.Number, result.Number)

--- a/primitives/types/inherent_data_test.go
+++ b/primitives/types/inherent_data_test.go
@@ -51,7 +51,7 @@ func Test_InherentData_Decode(t *testing.T) {
 	buffer.Write(expectEncoded)
 
 	result, err := DecodeInherentData(buffer)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	buffer.Reset()
 	buffer.Write(sc.SequenceU8ToBytes(result.data[key0]))

--- a/primitives/types/invalid_transaction.go
+++ b/primitives/types/invalid_transaction.go
@@ -146,6 +146,6 @@ func DecodeInvalidTransaction(buffer *bytes.Buffer) (InvalidTransaction, error) 
 	case InvalidTransactionBadSigner:
 		return NewInvalidTransactionBadSigner(), nil
 	default:
-		return InvalidTransaction{}, NewTypeError("InvalidTransaction")
+		return InvalidTransaction{}, newTypeError("InvalidTransaction")
 	}
 }

--- a/primitives/types/invalid_transaction.go
+++ b/primitives/types/invalid_transaction.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 
 	sc "github.com/LimeChain/goscale"
-	"github.com/LimeChain/gosemble/primitives/log"
 )
 
 const (
@@ -147,8 +146,6 @@ func DecodeInvalidTransaction(buffer *bytes.Buffer) (InvalidTransaction, error) 
 	case InvalidTransactionBadSigner:
 		return NewInvalidTransactionBadSigner(), nil
 	default:
-		log.Critical("invalid InvalidTransaction type")
+		return InvalidTransaction{}, NewTypeError("InvalidTransaction")
 	}
-
-	panic("unreachable")
 }

--- a/primitives/types/invalid_transaction_test.go
+++ b/primitives/types/invalid_transaction_test.go
@@ -80,7 +80,7 @@ func Test_DecodeInvalidTransaction_Call(t *testing.T) {
 	buffer.WriteByte(0)
 
 	result, err := DecodeInvalidTransaction(buffer)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, NewInvalidTransactionCall(), result)
 }
@@ -90,7 +90,7 @@ func Test_DecodeInvalidTransaction_Payment(t *testing.T) {
 	buffer.WriteByte(1)
 
 	result, err := DecodeInvalidTransaction(buffer)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, NewInvalidTransactionPayment(), result)
 }
@@ -100,7 +100,7 @@ func Test_DecodeInvalidTransaction_Future(t *testing.T) {
 	buffer.WriteByte(2)
 
 	result, err := DecodeInvalidTransaction(buffer)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, NewInvalidTransactionFuture(), result)
 }
@@ -110,7 +110,7 @@ func Test_DecodeInvalidTransaction_Stale(t *testing.T) {
 	buffer.WriteByte(3)
 
 	result, err := DecodeInvalidTransaction(buffer)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, NewInvalidTransactionStale(), result)
 }
@@ -120,7 +120,7 @@ func Test_DecodeInvalidTransaction_BadProof(t *testing.T) {
 	buffer.WriteByte(4)
 
 	result, err := DecodeInvalidTransaction(buffer)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, NewInvalidTransactionBadProof(), result)
 }
@@ -130,7 +130,7 @@ func Test_DecodeInvalidTransaction_AncientBirthBlock(t *testing.T) {
 	buffer.WriteByte(5)
 
 	result, err := DecodeInvalidTransaction(buffer)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, NewInvalidTransactionAncientBirthBlock(), result)
 }
@@ -140,7 +140,7 @@ func Test_DecodeInvalidTransaction_ExhaustsResources(t *testing.T) {
 	buffer.WriteByte(6)
 
 	result, err := DecodeInvalidTransaction(buffer)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, NewInvalidTransactionExhaustsResources(), result)
 }
@@ -152,7 +152,7 @@ func Test_DecodeInvalidTransaction_Custom(t *testing.T) {
 	buffer.WriteByte(byte(customError))
 
 	result, err := DecodeInvalidTransaction(buffer)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, NewInvalidTransactionCustom(customError), result)
 }
@@ -162,7 +162,7 @@ func Test_DecodeInvalidTransaction_BadMandatory(t *testing.T) {
 	buffer.WriteByte(8)
 
 	result, err := DecodeInvalidTransaction(buffer)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, NewInvalidTransactionBadMandatory(), result)
 }
@@ -172,7 +172,7 @@ func Test_DecodeInvalidTransaction_MandatoryValidation(t *testing.T) {
 	buffer.WriteByte(9)
 
 	result, err := DecodeInvalidTransaction(buffer)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, NewInvalidTransactionMandatoryValidation(), result)
 }
@@ -182,16 +182,18 @@ func Test_DecodeInvalidTransaction_BadSigner(t *testing.T) {
 	buffer.WriteByte(10)
 
 	result, err := DecodeInvalidTransaction(buffer)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, NewInvalidTransactionBadSigner(), result)
 }
 
-func Test_DecodeInvalidTransaction_Panics(t *testing.T) {
+func Test_DecodeInvalidTransaction_TypeError(t *testing.T) {
 	buffer := &bytes.Buffer{}
 	buffer.WriteByte(50)
 
-	assert.PanicsWithValue(t, "invalid InvalidTransaction type", func() {
-		DecodeInvalidTransaction(buffer)
-	})
+	res, err := DecodeInvalidTransaction(buffer)
+
+	assert.Error(t, err)
+	assert.Equal(t, "not a valid 'InvalidTransaction' type", err.Error())
+	assert.Equal(t, InvalidTransaction{}, res)
 }

--- a/primitives/types/last_runtime_upgrade_info_test.go
+++ b/primitives/types/last_runtime_upgrade_info_test.go
@@ -32,7 +32,7 @@ func Test_DecodeLastRuntimeUpgradeInfo(t *testing.T) {
 	buffer := bytes.NewBuffer(expectBytesLastRuntimeUpgradeInfo)
 
 	result, err := DecodeLastRuntimeUpgradeInfo(buffer)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, lrui, result)
 }

--- a/primitives/types/lookup.go
+++ b/primitives/types/lookup.go
@@ -18,7 +18,7 @@ func lookupAddress(a MultiAddress) (sc.Option[Address32], error) {
 	if a.IsAccountId() {
 		accountId, err := a.AsAccountId()
 		if err != nil {
-			return sc.NewOption[Address32](nil), nil
+			return sc.NewOption[Address32](nil), err
 		}
 		return sc.NewOption[Address32](accountId.Address32), nil
 	}
@@ -26,7 +26,7 @@ func lookupAddress(a MultiAddress) (sc.Option[Address32], error) {
 	if a.IsAddress32() {
 		address32, err := a.AsAddress32()
 		if err != nil {
-			return sc.NewOption[Address32](nil), nil
+			return sc.NewOption[Address32](nil), err
 		}
 		return sc.NewOption[Address32](address32), nil
 	}
@@ -34,9 +34,9 @@ func lookupAddress(a MultiAddress) (sc.Option[Address32], error) {
 	if a.IsAccountIndex() {
 		index, err := a.AsAccountIndex()
 		if err != nil {
-			return sc.NewOption[Address32](nil), nil
+			return sc.NewOption[Address32](nil), err
 		}
-		return lookupIndex(index), err
+		return lookupIndex(index), nil
 	}
 
 	return sc.NewOption[Address32](nil), nil

--- a/primitives/types/lookup_test.go
+++ b/primitives/types/lookup_test.go
@@ -8,41 +8,40 @@ import (
 )
 
 var (
-	multiAddressId = NewMultiAddressId(
-		AccountId{
-			Address32: NewAddress32(sc.BytesToSequenceU8(signerAddressBytes)...),
-		},
-	)
+	expectedAccountId, _ = NewAddress32(sc.BytesToSequenceU8(signerAddressBytes)...)
+
+	multiAddressId = NewMultiAddressId(AccountId{Address32: expectedAccountId})
 	multiAddress32 = NewMultiAddress32(
 		Address32{
 			sc.BytesToFixedSequenceU8(signerAddressBytes),
 		},
 	)
 	multiAddressIndex   = NewMultiAddressIndex(accountIndex)
-	expectedAccountId   = NewAddress32(sc.BytesToSequenceU8(signerAddressBytes)...)
 	invalidMultiAddress = MultiAddress{sc.NewVaryingData(sc.U8(5), sc.ToCompact(accountIndex))}
+
+	expectedTransactionCannotLookupErr, _ = NewTransactionValidityError(NewUnknownTransactionCannotLookup())
 )
 
 func Test_Lookup_AccountId(t *testing.T) {
 	result, err := Lookup(multiAddressId)
 	assert.Nil(t, err)
-	assert.Equal(t, result, expectedAccountId)
+	assert.Equal(t, expectedAccountId, result)
 }
 
 func Test_Lookup_Address32(t *testing.T) {
 	result, err := Lookup(multiAddress32)
 	assert.Nil(t, err)
-	assert.Equal(t, result, expectedAccountId)
+	assert.Equal(t, expectedAccountId, result)
 }
 
 func Test_Lookup_AccountIndex(t *testing.T) {
 	result, err := Lookup(multiAddressIndex)
-	assert.Equal(t, err, NewTransactionValidityError(NewUnknownTransactionCannotLookup()))
-	assert.Equal(t, result, Address32{})
+	assert.Equal(t, expectedTransactionCannotLookupErr, err)
+	assert.Equal(t, Address32{}, result)
 }
 
 func Test_Lookup_MultiAddress_NotValid(t *testing.T) {
 	result, err := Lookup(invalidMultiAddress)
-	assert.Equal(t, err, NewTransactionValidityError(NewUnknownTransactionCannotLookup()))
-	assert.Equal(t, result, Address32{})
+	assert.Equal(t, expectedTransactionCannotLookupErr, err)
+	assert.Equal(t, Address32{}, result)
 }

--- a/primitives/types/metadata.go
+++ b/primitives/types/metadata.go
@@ -79,7 +79,6 @@ func DecodeMetadata(buffer *bytes.Buffer) (Metadata, error) {
 		return Metadata{}, err
 	}
 	if metaReserved != MetadataReserved {
-		log.Critical("metadata reserved mismatch: expect [" + strconv.Itoa(int(MetadataReserved)) + "], actual [" + strconv.Itoa(int(metaReserved)) + "]")
 		return Metadata{}, errors.New("metadata reserved mismatch: expect [" + strconv.Itoa(int(MetadataReserved)) + "], actual [" + strconv.Itoa(int(metaReserved)) + "]")
 	}
 
@@ -102,7 +101,6 @@ func DecodeMetadata(buffer *bytes.Buffer) (Metadata, error) {
 		}
 		return Metadata{Version: MetadataVersion15, DataV15: data}, nil
 	default:
-		log.Critical("metadata version mismatch: expect [" + strconv.Itoa(int(MetadataVersion14)) + "or" + strconv.Itoa(int(MetadataVersion15)) + "] , actual [" + strconv.Itoa(int(version)) + "]")
 		return Metadata{}, errors.New("metadata version mismatch: expect [" + strconv.Itoa(int(MetadataVersion14)) + "or" + strconv.Itoa(int(MetadataVersion15)) + "] , actual [" + strconv.Itoa(int(version)) + "]")
 	}
 }

--- a/primitives/types/metadata_module.go
+++ b/primitives/types/metadata_module.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 
 	sc "github.com/LimeChain/goscale"
-	"github.com/LimeChain/gosemble/primitives/log"
 )
 
 const (
@@ -280,10 +279,8 @@ func DecodeMetadataModuleStorageEntryModifier(buffer *bytes.Buffer) (MetadataMod
 	case MetadataModuleStorageEntryModifierDefault:
 		return MetadataModuleStorageEntryModifierDefault, nil
 	default:
-		log.Critical("invalid DecodeMetadataModuleStorageEntryModifier type")
+		return MetadataModuleStorageEntryModifier(0), NewTypeError("MetadataModuleStorageEntryModifier")
 	}
-
-	panic("unreachable")
 }
 
 const (
@@ -329,10 +326,8 @@ func DecodeMetadataModuleStorageEntryDefinition(buffer *bytes.Buffer) (MetadataM
 		}
 		return NewMetadataModuleStorageEntryDefinitionMap(storageHashFuncs, key, value), nil
 	default:
-		log.Critical("invalid MetadataModuleStorageEntryDefinition type")
+		return MetadataModuleStorageEntryDefinition{}, NewTypeError("MetadataModuleStorageEntryDefinition")
 	}
-
-	panic("unreachable")
 }
 
 type MetadataModuleConstant struct {
@@ -420,10 +415,7 @@ func DecodeMetadataModuleStorageHashFunc(buffer *bytes.Buffer) (MetadataModuleSt
 		return MetadataModuleStorageHashFuncMultiXX64, nil
 	case MetadataModuleStorageHashFuncIdentity:
 		return MetadataModuleStorageHashFuncIdentity, nil
-
 	default:
-		log.Critical("invalid MetadataModuleStorageHashFunc type")
+		return MetadataModuleStorageHashFunc(0), NewTypeError("MetadataModuleStorageHashFunc")
 	}
-
-	panic("unreachable")
 }

--- a/primitives/types/metadata_module.go
+++ b/primitives/types/metadata_module.go
@@ -279,7 +279,7 @@ func DecodeMetadataModuleStorageEntryModifier(buffer *bytes.Buffer) (MetadataMod
 	case MetadataModuleStorageEntryModifierDefault:
 		return MetadataModuleStorageEntryModifierDefault, nil
 	default:
-		return MetadataModuleStorageEntryModifier(0), NewTypeError("MetadataModuleStorageEntryModifier")
+		return MetadataModuleStorageEntryModifier(0), newTypeError("MetadataModuleStorageEntryModifier")
 	}
 }
 
@@ -326,7 +326,7 @@ func DecodeMetadataModuleStorageEntryDefinition(buffer *bytes.Buffer) (MetadataM
 		}
 		return NewMetadataModuleStorageEntryDefinitionMap(storageHashFuncs, key, value), nil
 	default:
-		return MetadataModuleStorageEntryDefinition{}, NewTypeError("MetadataModuleStorageEntryDefinition")
+		return MetadataModuleStorageEntryDefinition{}, newTypeError("MetadataModuleStorageEntryDefinition")
 	}
 }
 
@@ -416,6 +416,6 @@ func DecodeMetadataModuleStorageHashFunc(buffer *bytes.Buffer) (MetadataModuleSt
 	case MetadataModuleStorageHashFuncIdentity:
 		return MetadataModuleStorageHashFuncIdentity, nil
 	default:
-		return MetadataModuleStorageHashFunc(0), NewTypeError("MetadataModuleStorageHashFunc")
+		return MetadataModuleStorageHashFunc(0), newTypeError("MetadataModuleStorageHashFunc")
 	}
 }

--- a/primitives/types/metadata_type_definition.go
+++ b/primitives/types/metadata_type_definition.go
@@ -116,7 +116,7 @@ func DecodeMetadataTypeDefinition(buffer *bytes.Buffer) (MetadataTypeDefinition,
 		}
 		return NewMetadataTypeDefinitionBitSequence(storeOrder, orderType), nil
 	default:
-		return MetadataTypeDefinition{}, NewTypeError("MetadataTypeDefinition")
+		return MetadataTypeDefinition{}, newTypeError("MetadataTypeDefinition")
 	}
 }
 
@@ -305,6 +305,6 @@ func DecodeMetadataDefinitionPrimitive(buffer *bytes.Buffer) (MetadataDefinition
 	case MetadataDefinitionPrimitiveI256:
 		return MetadataDefinitionPrimitiveI256, nil
 	default:
-		return MetadataDefinitionPrimitive(0), NewTypeError("MetadataDefinitionPrimitive")
+		return MetadataDefinitionPrimitive(0), newTypeError("MetadataDefinitionPrimitive")
 	}
 }

--- a/primitives/types/metadata_type_definition.go
+++ b/primitives/types/metadata_type_definition.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 
 	sc "github.com/LimeChain/goscale"
-	"github.com/LimeChain/gosemble/primitives/log"
 )
 
 const (
@@ -117,10 +116,8 @@ func DecodeMetadataTypeDefinition(buffer *bytes.Buffer) (MetadataTypeDefinition,
 		}
 		return NewMetadataTypeDefinitionBitSequence(storeOrder, orderType), nil
 	default:
-		log.Critical("invalid MetadataTypeDefinition type")
+		return MetadataTypeDefinition{}, NewTypeError("MetadataTypeDefinition")
 	}
-
-	panic("unreachable")
 }
 
 type MetadataTypeDefinitionField struct {
@@ -307,10 +304,7 @@ func DecodeMetadataDefinitionPrimitive(buffer *bytes.Buffer) (MetadataDefinition
 		return MetadataDefinitionPrimitiveI128, nil
 	case MetadataDefinitionPrimitiveI256:
 		return MetadataDefinitionPrimitiveI256, nil
-
 	default:
-		log.Critical("invalid MetadataDefinitionPrimitive type")
+		return MetadataDefinitionPrimitive(0), NewTypeError("MetadataDefinitionPrimitive")
 	}
-
-	panic("unreachable")
 }

--- a/primitives/types/module.go
+++ b/primitives/types/module.go
@@ -17,22 +17,11 @@ type Module interface {
 	Metadata() (sc.Sequence[MetadataType], MetadataModule)
 }
 
-func GetModule(moduleIndex sc.U8, modules []Module) (Module, bool) {
-	for _, module := range modules {
-		if module.GetIndex() == moduleIndex {
-			return module, true
-		}
-	}
-
-	return nil, false
-}
-
-func MustGetModule(moduleIndex sc.U8, modules []Module) (Module, error) {
+func GetModule(moduleIndex sc.U8, modules []Module) (Module, error) {
 	for _, module := range modules {
 		if module.GetIndex() == moduleIndex {
 			return module, nil
 		}
 	}
-
-	return nil, errors.New("module [" + strconv.Itoa(int(moduleIndex)) + "] not found.")
+	return nil, errors.New("module with index [" + strconv.Itoa(int(moduleIndex)) + "] not found.")
 }

--- a/primitives/types/module.go
+++ b/primitives/types/module.go
@@ -25,3 +25,13 @@ func GetModule(moduleIndex sc.U8, modules []Module) (Module, error) {
 	}
 	return nil, errors.New("module with index [" + strconv.Itoa(int(moduleIndex)) + "] not found.")
 }
+
+func MustGetModule(moduleIndex sc.U8, modules []Module) Module {
+	for _, module := range modules {
+		if module.GetIndex() == moduleIndex {
+			return module
+		}
+	}
+
+	panic("module [" + strconv.Itoa(int(moduleIndex)) + "] not found.")
+}

--- a/primitives/types/module.go
+++ b/primitives/types/module.go
@@ -1,10 +1,10 @@
 package types
 
 import (
+	"errors"
 	"strconv"
 
 	sc "github.com/LimeChain/goscale"
-	"github.com/LimeChain/gosemble/primitives/log"
 )
 
 type Module interface {
@@ -27,14 +27,12 @@ func GetModule(moduleIndex sc.U8, modules []Module) (Module, bool) {
 	return nil, false
 }
 
-func MustGetModule(moduleIndex sc.U8, modules []Module) Module {
+func MustGetModule(moduleIndex sc.U8, modules []Module) (Module, error) {
 	for _, module := range modules {
 		if module.GetIndex() == moduleIndex {
-			return module
+			return module, nil
 		}
 	}
 
-	log.Critical("module [" + strconv.Itoa(int(moduleIndex)) + "] not found.")
-
-	panic("unreachable")
+	return nil, errors.New("module [" + strconv.Itoa(int(moduleIndex)) + "] not found.")
 }

--- a/primitives/types/module_test.go
+++ b/primitives/types/module_test.go
@@ -55,7 +55,9 @@ func Test_GetModule_FailWhenNonExistent(t *testing.T) {
 func Test_MustGetModule(t *testing.T) {
 	setup()
 	for i := 0; i < numModules; i++ {
-		m := MustGetModule(sc.U8(i), modules)
+		m, err := MustGetModule(sc.U8(i), modules)
+
+		assert.NoError(t, err)
 		assert.Equal(t, m.GetIndex(), sc.U8(i))
 		assert.Equal(t, m, modules[i])
 	}

--- a/primitives/types/module_test.go
+++ b/primitives/types/module_test.go
@@ -38,8 +38,8 @@ func setup() {
 func Test_GetModule(t *testing.T) {
 	setup()
 	for i := 0; i < numModules; i++ {
-		m, ok := GetModule(sc.U8(i), modules)
-		assert.True(t, ok)
+		m, err := GetModule(sc.U8(i), modules)
+		assert.NoError(t, err)
 		assert.Equal(t, m.GetIndex(), sc.U8(i))
 		assert.Equal(t, m, modules[i])
 	}
@@ -47,15 +47,15 @@ func Test_GetModule(t *testing.T) {
 
 func Test_GetModule_FailWhenNonExistent(t *testing.T) {
 	setup()
-	m, ok := GetModule(sc.U8(numModules), modules)
-	assert.False(t, ok)
+	m, err := GetModule(sc.U8(numModules), modules)
+	assert.Error(t, err)
 	assert.Nil(t, m)
 }
 
 func Test_MustGetModule(t *testing.T) {
 	setup()
 	for i := 0; i < numModules; i++ {
-		m, err := MustGetModule(sc.U8(i), modules)
+		m, err := GetModule(sc.U8(i), modules)
 
 		assert.NoError(t, err)
 		assert.Equal(t, m.GetIndex(), sc.U8(i))
@@ -63,9 +63,12 @@ func Test_MustGetModule(t *testing.T) {
 	}
 }
 
-func Test_MustGetModule_PanicWhenNonExistent(t *testing.T) {
+func Test_MustGetModule_ErrorNonExistent(t *testing.T) {
 	setup()
-	assert.PanicsWithValue(t, "module ["+strconv.Itoa(int(numModules))+"] not found.", func() {
-		MustGetModule(sc.U8(numModules), modules)
-	})
+
+	mod, err := GetModule(sc.U8(numModules), modules)
+
+	assert.Error(t, err)
+	assert.Equal(t, err.Error(), "module with index ["+strconv.Itoa(int(numModules))+"] not found.")
+	assert.Nil(t, mod)
 }

--- a/primitives/types/multi_address.go
+++ b/primitives/types/multi_address.go
@@ -2,9 +2,9 @@ package types
 
 import (
 	"bytes"
+	"errors"
 
 	sc "github.com/LimeChain/goscale"
-	"github.com/LimeChain/gosemble/primitives/log"
 )
 
 // AccountId It's an account ID (pubkey).
@@ -45,11 +45,11 @@ type Address32 struct {
 	sc.FixedSequence[sc.U8] // size 32
 }
 
-func NewAddress32(values ...sc.U8) Address32 {
+func NewAddress32(values ...sc.U8) (Address32, error) {
 	if len(values) != 32 {
-		log.Critical("Address32 should be of size 32")
+		return Address32{}, errors.New("Address32 should be of size 32")
 	}
-	return Address32{sc.NewFixedSequence(32, values...)}
+	return Address32{sc.NewFixedSequence(32, values...)}, nil
 }
 
 func DecodeAddress32(buffer *bytes.Buffer) (Address32, error) {
@@ -65,11 +65,11 @@ type Address20 struct {
 	sc.FixedSequence[sc.U8] // size 20
 }
 
-func NewAddress20(values ...sc.U8) Address20 {
+func NewAddress20(values ...sc.U8) (Address20, error) {
 	if len(values) != 20 {
-		log.Critical("Address20 should be of size 20")
+		return Address20{}, errors.New("Address20 should be of size 20")
 	}
-	return Address20{sc.NewFixedSequence(20, values...)}
+	return Address20{sc.NewFixedSequence(20, values...)}, nil
 }
 
 func DecodeAddress20(buffer *bytes.Buffer) (Address20, error) {
@@ -151,10 +151,8 @@ func DecodeMultiAddress(buffer *bytes.Buffer) (MultiAddress, error) {
 		}
 		return NewMultiAddress20(addr20), nil
 	default:
-		log.Critical("invalid MultiAddress type in Decode")
+		return MultiAddress{}, NewTypeError("MultiAddress")
 	}
-
-	panic("unreachable")
 }
 
 func (a MultiAddress) IsAccountId() bool {
@@ -166,14 +164,12 @@ func (a MultiAddress) IsAccountId() bool {
 	}
 }
 
-func (a MultiAddress) AsAccountId() AccountId {
+func (a MultiAddress) AsAccountId() (AccountId, error) {
 	if a.IsAccountId() {
-		return a.VaryingData[1].(AccountId)
+		return a.VaryingData[1].(AccountId), nil
 	} else {
-		log.Critical("not an AccountId type")
+		return AccountId{}, NewTypeError("AccountId")
 	}
-
-	panic("unreachable")
 }
 
 func (a MultiAddress) IsAccountIndex() bool {
@@ -185,16 +181,13 @@ func (a MultiAddress) IsAccountIndex() bool {
 	}
 }
 
-func (a MultiAddress) AsAccountIndex() AccountIndex {
+func (a MultiAddress) AsAccountIndex() (AccountIndex, error) {
 	if a.IsAccountIndex() {
 		compact := a.VaryingData[1].(sc.Compact)
-
-		return sc.U32(compact.ToBigInt().Uint64())
+		return sc.U32(compact.ToBigInt().Uint64()), nil
 	} else {
-		log.Critical("not an AccountIndex type")
+		return 0, NewTypeError("AccountIndex")
 	}
-
-	panic("unreachable")
 }
 
 func (a MultiAddress) IsRaw() bool {
@@ -206,14 +199,12 @@ func (a MultiAddress) IsRaw() bool {
 	}
 }
 
-func (a MultiAddress) AsRaw() AccountRaw {
+func (a MultiAddress) AsRaw() (AccountRaw, error) {
 	if a.IsRaw() {
-		return a.VaryingData[1].(AccountRaw)
+		return a.VaryingData[1].(AccountRaw), nil
 	} else {
-		log.Critical("not an AccountRaw type")
+		return AccountRaw{}, NewTypeError("AccountRaw")
 	}
-
-	panic("unreachable")
 }
 
 func (a MultiAddress) IsAddress32() bool {
@@ -225,14 +216,12 @@ func (a MultiAddress) IsAddress32() bool {
 	}
 }
 
-func (a MultiAddress) AsAddress32() Address32 {
+func (a MultiAddress) AsAddress32() (Address32, error) {
 	if a.IsAddress32() {
-		return a.VaryingData[1].(Address32)
+		return a.VaryingData[1].(Address32), nil
 	} else {
-		log.Critical("not an Address32 type")
+		return Address32{}, NewTypeError("Address32")
 	}
-
-	panic("unreachable")
 }
 
 func (a MultiAddress) IsAddress20() bool {
@@ -244,12 +233,10 @@ func (a MultiAddress) IsAddress20() bool {
 	}
 }
 
-func (a MultiAddress) AsAddress20() Address20 {
+func (a MultiAddress) AsAddress20() (Address20, error) {
 	if a.IsAddress20() {
-		return a.VaryingData[1].(Address20)
+		return a.VaryingData[1].(Address20), nil
 	} else {
-		log.Critical("not an Address20 type")
+		return Address20{}, NewTypeError("Address20")
 	}
-
-	panic("unreachable")
 }

--- a/primitives/types/multi_address.go
+++ b/primitives/types/multi_address.go
@@ -151,7 +151,7 @@ func DecodeMultiAddress(buffer *bytes.Buffer) (MultiAddress, error) {
 		}
 		return NewMultiAddress20(addr20), nil
 	default:
-		return MultiAddress{}, NewTypeError("MultiAddress")
+		return MultiAddress{}, newTypeError("MultiAddress")
 	}
 }
 
@@ -168,7 +168,7 @@ func (a MultiAddress) AsAccountId() (AccountId, error) {
 	if a.IsAccountId() {
 		return a.VaryingData[1].(AccountId), nil
 	} else {
-		return AccountId{}, NewTypeError("AccountId")
+		return AccountId{}, newTypeError("AccountId")
 	}
 }
 
@@ -186,7 +186,7 @@ func (a MultiAddress) AsAccountIndex() (AccountIndex, error) {
 		compact := a.VaryingData[1].(sc.Compact)
 		return sc.U32(compact.ToBigInt().Uint64()), nil
 	} else {
-		return 0, NewTypeError("AccountIndex")
+		return 0, newTypeError("AccountIndex")
 	}
 }
 
@@ -203,7 +203,7 @@ func (a MultiAddress) AsRaw() (AccountRaw, error) {
 	if a.IsRaw() {
 		return a.VaryingData[1].(AccountRaw), nil
 	} else {
-		return AccountRaw{}, NewTypeError("AccountRaw")
+		return AccountRaw{}, newTypeError("AccountRaw")
 	}
 }
 
@@ -220,7 +220,7 @@ func (a MultiAddress) AsAddress32() (Address32, error) {
 	if a.IsAddress32() {
 		return a.VaryingData[1].(Address32), nil
 	} else {
-		return Address32{}, NewTypeError("Address32")
+		return Address32{}, newTypeError("Address32")
 	}
 }
 
@@ -237,6 +237,6 @@ func (a MultiAddress) AsAddress20() (Address20, error) {
 	if a.IsAddress20() {
 		return a.VaryingData[1].(Address20), nil
 	} else {
-		return Address20{}, NewTypeError("Address20")
+		return Address20{}, newTypeError("Address20")
 	}
 }

--- a/primitives/types/multi_signature.go
+++ b/primitives/types/multi_signature.go
@@ -43,7 +43,7 @@ func (s MultiSignature) AsEd25519() (SignatureEd25519, error) {
 	if s.IsEd25519() {
 		return s.VaryingData[1].(SignatureEd25519), nil
 	} else {
-		return SignatureEd25519{}, NewTypeError("SignatureEd25519")
+		return SignatureEd25519{}, newTypeError("SignatureEd25519")
 	}
 }
 
@@ -60,7 +60,7 @@ func (s MultiSignature) AsSr25519() (SignatureSr25519, error) {
 	if s.IsSr25519() {
 		return s.VaryingData[1].(SignatureSr25519), nil
 	} else {
-		return SignatureSr25519{}, NewTypeError("SignatureSr25519")
+		return SignatureSr25519{}, newTypeError("SignatureSr25519")
 	}
 }
 
@@ -77,7 +77,7 @@ func (s MultiSignature) AsEcdsa() (SignatureEcdsa, error) {
 	if s.IsEcdsa() {
 		return s.VaryingData[1].(SignatureEcdsa), nil
 	} else {
-		return SignatureEcdsa{}, NewTypeError("SignatureEcdsa")
+		return SignatureEcdsa{}, newTypeError("SignatureEcdsa")
 	}
 }
 

--- a/primitives/types/multi_signature.go
+++ b/primitives/types/multi_signature.go
@@ -2,10 +2,10 @@ package types
 
 import (
 	"bytes"
+	"errors"
 	"strconv"
 
 	sc "github.com/LimeChain/goscale"
-	"github.com/LimeChain/gosemble/primitives/log"
 )
 
 const (
@@ -39,14 +39,12 @@ func (s MultiSignature) IsEd25519() bool {
 	}
 }
 
-func (s MultiSignature) AsEd25519() SignatureEd25519 {
+func (s MultiSignature) AsEd25519() (SignatureEd25519, error) {
 	if s.IsEd25519() {
-		return s.VaryingData[1].(SignatureEd25519)
+		return s.VaryingData[1].(SignatureEd25519), nil
 	} else {
-		log.Critical("not Ed25519 signature type")
+		return SignatureEd25519{}, NewTypeError("SignatureEd25519")
 	}
-
-	panic("unreachable")
 }
 
 func (s MultiSignature) IsSr25519() bool {
@@ -58,14 +56,12 @@ func (s MultiSignature) IsSr25519() bool {
 	}
 }
 
-func (s MultiSignature) AsSr25519() SignatureSr25519 {
+func (s MultiSignature) AsSr25519() (SignatureSr25519, error) {
 	if s.IsSr25519() {
-		return s.VaryingData[1].(SignatureSr25519)
+		return s.VaryingData[1].(SignatureSr25519), nil
 	} else {
-		log.Critical("not Sr25519 signature type")
+		return SignatureSr25519{}, NewTypeError("SignatureSr25519")
 	}
-
-	panic("unreachable")
 }
 
 func (s MultiSignature) IsEcdsa() bool {
@@ -77,14 +73,12 @@ func (s MultiSignature) IsEcdsa() bool {
 	}
 }
 
-func (s MultiSignature) AsEcdsa() SignatureEcdsa {
+func (s MultiSignature) AsEcdsa() (SignatureEcdsa, error) {
 	if s.IsEcdsa() {
-		return s.VaryingData[1].(SignatureEcdsa)
+		return s.VaryingData[1].(SignatureEcdsa), nil
 	} else {
-		log.Critical("not Ecdsa signature type")
+		return SignatureEcdsa{}, NewTypeError("SignatureEcdsa")
 	}
-
-	panic("unreachable")
 }
 
 func DecodeMultiSignature(buffer *bytes.Buffer) (MultiSignature, error) {
@@ -113,8 +107,6 @@ func DecodeMultiSignature(buffer *bytes.Buffer) (MultiSignature, error) {
 		}
 		return NewMultiSignatureEcdsa(ecdsa), nil
 	default:
-		log.Critical("invalid MultiSignature type in Decode: " + strconv.Itoa(int(b)))
+		return MultiSignature{}, errors.New("invalid MultiSignature type in Decode: " + strconv.Itoa(int(b)))
 	}
-
-	panic("unreachable")
 }

--- a/primitives/types/multi_signature_test.go
+++ b/primitives/types/multi_signature_test.go
@@ -102,13 +102,15 @@ func Test_DecodeMultiSignature(t *testing.T) {
 	}
 }
 
-func Test_DecodeMultiSignature_Panics(t *testing.T) {
+func Test_DecodeMultiSignature_TypeError(t *testing.T) {
 	buffer := &bytes.Buffer{}
 	buffer.WriteByte(3)
 
-	assert.PanicsWithValue(t, "invalid MultiSignature type in Decode: 3", func() {
-		DecodeMultiSignature(buffer)
-	})
+	result, err := DecodeMultiSignature(buffer)
+
+	assert.Error(t, err)
+	assert.Equal(t, "invalid MultiSignature type in Decode: 3", err.Error())
+	assert.Equal(t, MultiSignature{}, result)
 }
 
 func Test_MultiSignature_IsEd25519_True(t *testing.T) {
@@ -139,46 +141,66 @@ func Test_MultiSignature_IsEcdsa_False(t *testing.T) {
 }
 
 func Test_MultiSignature_AsEd25519(t *testing.T) {
-	result := multiSignatureEd25519.AsEd25519()
+	result, err := multiSignatureEd25519.AsEd25519()
 
+	assert.NoError(t, err)
 	assert.Equal(t, signatureEd25519, result)
 }
 
-func Test_MultiSignature_AsEd25519_Panics(t *testing.T) {
-	assert.PanicsWithValue(t, "not Ed25519 signature type", func() {
-		multiSignatureEcdsa.AsEd25519()
-	})
-	assert.PanicsWithValue(t, "not Ed25519 signature type", func() {
-		multiSignatureSr25519.AsEd25519()
-	})
+func Test_MultiSignature_Ecdsa_AsEd25519_TypeError(t *testing.T) {
+	result, err := multiSignatureEcdsa.AsEd25519()
+
+	assert.Error(t, err)
+	assert.Equal(t, "not a valid 'SignatureEd25519' type", err.Error())
+	assert.Equal(t, SignatureEd25519{}, result)
+}
+
+func Test_MultiSignature_Sr25519_AsEd25519_TypeError(t *testing.T) {
+	result, err := multiSignatureSr25519.AsEd25519()
+
+	assert.Error(t, err)
+	assert.Equal(t, "not a valid 'SignatureEd25519' type", err.Error())
+	assert.Equal(t, SignatureEd25519{}, result)
 }
 
 func Test_MultiSignature_AsSr25519(t *testing.T) {
-	result := multiSignatureSr25519.AsSr25519()
+	result, err := multiSignatureSr25519.AsSr25519()
 
+	assert.NoError(t, err)
 	assert.Equal(t, signatureSr25519, result)
 }
 
-func Test_MultiSignature_AsSr25519_Panics(t *testing.T) {
-	assert.PanicsWithValue(t, "not Sr25519 signature type", func() {
-		multiSignatureEcdsa.AsSr25519()
-	})
-	assert.PanicsWithValue(t, "not Sr25519 signature type", func() {
-		multiSignatureEd25519.AsSr25519()
-	})
+func Test_MultiSignature_AsSr25519_TypeError(t *testing.T) {
+	result, err := multiSignatureEcdsa.AsSr25519()
+
+	assert.Error(t, err)
+	assert.Equal(t, "not a valid 'SignatureSr25519' type", err.Error())
+	assert.Equal(t, SignatureSr25519{}, result)
+
+	result, err = multiSignatureEd25519.AsSr25519()
+
+	assert.Error(t, err)
+	assert.Equal(t, "not a valid 'SignatureSr25519' type", err.Error())
+	assert.Equal(t, SignatureSr25519{}, result)
 }
 
 func Test_MultiSignature_AsEcdsa(t *testing.T) {
-	result := multiSignatureEcdsa.AsEcdsa()
+	result, err := multiSignatureEcdsa.AsEcdsa()
 
+	assert.NoError(t, err)
 	assert.Equal(t, signatureEcdsa, result)
 }
 
-func Test_MultiSignature_AsEcdsa_Panics(t *testing.T) {
-	assert.PanicsWithValue(t, "not Ecdsa signature type", func() {
-		multiSignatureSr25519.AsEcdsa()
-	})
-	assert.PanicsWithValue(t, "not Ecdsa signature type", func() {
-		multiSignatureEd25519.AsEcdsa()
-	})
+func Test_MultiSignature_AsEcdsa_TypeError(t *testing.T) {
+	result, err := multiSignatureSr25519.AsEcdsa()
+
+	assert.Error(t, err)
+	assert.Equal(t, "not a valid 'SignatureEcdsa' type", err.Error())
+	assert.Equal(t, SignatureEcdsa{}, result)
+
+	result, err = multiSignatureEd25519.AsEcdsa()
+
+	assert.Error(t, err)
+	assert.Equal(t, "not a valid 'SignatureEcdsa' type", err.Error())
+	assert.Equal(t, SignatureEcdsa{}, result)
 }

--- a/primitives/types/pays.go
+++ b/primitives/types/pays.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 
 	sc "github.com/LimeChain/goscale"
-	"github.com/LimeChain/gosemble/primitives/log"
 )
 
 const (
@@ -37,8 +36,6 @@ func DecodePays(buffer *bytes.Buffer) (Pays, error) {
 	case PaysNo:
 		return NewPaysNo(), nil
 	default:
-		log.Critical("invalid Pays type")
+		return nil, NewTypeError("Pays")
 	}
-
-	panic("unreachable")
 }

--- a/primitives/types/pays.go
+++ b/primitives/types/pays.go
@@ -36,6 +36,6 @@ func DecodePays(buffer *bytes.Buffer) (Pays, error) {
 	case PaysNo:
 		return NewPaysNo(), nil
 	default:
-		return nil, NewTypeError("Pays")
+		return nil, newTypeError("Pays")
 	}
 }

--- a/primitives/types/pays_test.go
+++ b/primitives/types/pays_test.go
@@ -21,7 +21,7 @@ func Test_DecodePays_Yes(t *testing.T) {
 	buffer.WriteByte(0)
 
 	result, err := DecodePays(buffer)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, NewPaysYes(), result)
 }
@@ -31,16 +31,18 @@ func Test_DecodePays_No(t *testing.T) {
 	buffer.WriteByte(1)
 
 	result, err := DecodePays(buffer)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, NewPaysNo(), result)
 }
 
-func Test_DecodePays_Panics(t *testing.T) {
+func Test_DecodePays_TypeError(t *testing.T) {
 	buffer := &bytes.Buffer{}
 	buffer.WriteByte(2)
 
-	assert.PanicsWithValue(t, "invalid Pays type", func() {
-		DecodePays(buffer)
-	})
+	res, err := DecodePays(buffer)
+
+	assert.Error(t, err)
+	assert.Equal(t, "not a valid 'Pays' type", err.Error())
+	assert.Nil(t, res)
 }

--- a/primitives/types/per_dispatch_class.go
+++ b/primitives/types/per_dispatch_class.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 
 	sc "github.com/LimeChain/goscale"
-	"github.com/LimeChain/gosemble/primitives/log"
 )
 
 // A struct holding value for each `DispatchClass`.
@@ -48,17 +47,15 @@ func (pdc PerDispatchClass[T]) Bytes() []byte {
 }
 
 // Get current value for given class.
-func (pdc *PerDispatchClass[T]) Get(class DispatchClass) *T {
+func (pdc *PerDispatchClass[T]) Get(class DispatchClass) (*T, error) {
 	switch class.VaryingData[0] {
 	case DispatchClassNormal:
-		return &pdc.Normal
+		return &pdc.Normal, nil
 	case DispatchClassOperational:
-		return &pdc.Operational
+		return &pdc.Operational, nil
 	case DispatchClassMandatory:
-		return &pdc.Mandatory
+		return &pdc.Mandatory, nil
 	default:
-		log.Critical("invalid DispatchClass type")
+		return nil, NewTypeError("DispatchClass")
 	}
-
-	panic("unreachable")
 }

--- a/primitives/types/per_dispatch_class.go
+++ b/primitives/types/per_dispatch_class.go
@@ -56,6 +56,6 @@ func (pdc *PerDispatchClass[T]) Get(class DispatchClass) (*T, error) {
 	case DispatchClassMandatory:
 		return &pdc.Mandatory, nil
 	default:
-		return nil, NewTypeError("DispatchClass")
+		return nil, newTypeError("DispatchClass")
 	}
 }

--- a/primitives/types/per_dispatch_class_test.go
+++ b/primitives/types/per_dispatch_class_test.go
@@ -41,15 +41,25 @@ func Test_PerDispatchClass_Bytes(t *testing.T) {
 }
 
 func Test_PerDispatchClass_Get(t *testing.T) {
-	assert.Equal(t, sc.U8(1), *targetPerDispatchClass.Get(NewDispatchClassNormal()))
-	assert.Equal(t, sc.U8(2), *targetPerDispatchClass.Get(NewDispatchClassOperational()))
-	assert.Equal(t, sc.U8(3), *targetPerDispatchClass.Get(NewDispatchClassMandatory()))
+	normal, err := targetPerDispatchClass.Get(NewDispatchClassNormal())
+	assert.NoError(t, err)
+	assert.Equal(t, sc.U8(1), *normal)
+
+	operational, err := targetPerDispatchClass.Get(NewDispatchClassOperational())
+	assert.NoError(t, err)
+	assert.Equal(t, sc.U8(2), *operational)
+
+	mandatory, err := targetPerDispatchClass.Get(NewDispatchClassMandatory())
+	assert.NoError(t, err)
+	assert.Equal(t, sc.U8(3), *mandatory)
 }
 
-func Test_PerDispatchClass_Get_Panic(t *testing.T) {
+func Test_PerDispatchClass_Get_TypeError(t *testing.T) {
 	unknownDispatchClass := DispatchClass{sc.NewVaryingData(sc.U8(3))}
 
-	assert.PanicsWithValue(t, "invalid DispatchClass type", func() {
-		targetPerDispatchClass.Get(unknownDispatchClass)
-	})
+	result, err := targetPerDispatchClass.Get(unknownDispatchClass)
+
+	assert.Error(t, err)
+	assert.Equal(t, "not a valid 'DispatchClass' type", err.Error())
+	assert.Nil(t, result)
 }

--- a/primitives/types/perthings.go
+++ b/primitives/types/perthings.go
@@ -2,9 +2,9 @@ package types
 
 import (
 	"bytes"
+	"errors"
 
 	sc "github.com/LimeChain/goscale"
-	"github.com/LimeChain/gosemble/primitives/log"
 )
 
 type Perbill struct {
@@ -29,18 +29,16 @@ func (p Perbill) Bytes() []byte {
 	return sc.EncodedBytes(p)
 }
 
-func (p Perbill) Mul(v sc.Encodable) sc.Encodable {
+func (p Perbill) Mul(v sc.Encodable) (sc.Encodable, error) {
 	switch v := v.(type) {
 	case sc.U32:
-		return (v / 100) * p.Percentage
+		return (v / 100) * p.Percentage, nil
 	case Weight:
-		return Weight{
-			RefTime:   (v.RefTime / 100) * sc.U64(p.Percentage),
-			ProofSize: (v.ProofSize / 100) * sc.U64(p.Percentage),
-		}
+		return WeightFromParts(
+			(v.RefTime/100)*sc.U64(p.Percentage),
+			(v.ProofSize/100)*sc.U64(p.Percentage),
+		), nil
 	default:
-		log.Critical("unsupported type")
+		return nil, errors.New("unsupported type")
 	}
-
-	panic("unreachable")
 }

--- a/primitives/types/post_dispatch_info_test.go
+++ b/primitives/types/post_dispatch_info_test.go
@@ -37,7 +37,7 @@ func Test_DecodePostDispatchInfo(t *testing.T) {
 	buffer := bytes.NewBuffer(expectBytesPostDispatchInfo)
 
 	result, err := DecodePostDispatchInfo(buffer)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, postDispatchInfo, result)
 }

--- a/primitives/types/public_key_test.go
+++ b/primitives/types/public_key_test.go
@@ -15,7 +15,7 @@ func Test_DecodePublicKey(t *testing.T) {
 
 	buffer := bytes.NewBuffer(bytesPublicKey)
 	result, err := DecodePublicKey(buffer)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, expect, result)
 }

--- a/primitives/types/raw_origin.go
+++ b/primitives/types/raw_origin.go
@@ -48,7 +48,7 @@ func (o RawOrigin) IsNoneOrigin() bool {
 
 func (o RawOrigin) AsSigned() (Address32, error) {
 	if !o.IsSignedOrigin() {
-		return Address32{}, NewTypeError("RawOrigin")
+		return Address32{}, newTypeError("RawOrigin")
 	}
 	return o.VaryingData[1].(Address32), nil
 }

--- a/primitives/types/raw_origin.go
+++ b/primitives/types/raw_origin.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	sc "github.com/LimeChain/goscale"
-	"github.com/LimeChain/gosemble/primitives/log"
 )
 
 const (
@@ -47,10 +46,9 @@ func (o RawOrigin) IsNoneOrigin() bool {
 	return o.VaryingData[0] == RawOriginNone
 }
 
-func (o RawOrigin) AsSigned() Address32 {
+func (o RawOrigin) AsSigned() (Address32, error) {
 	if !o.IsSignedOrigin() {
-		log.Critical("not a signed origin")
+		return Address32{}, NewTypeError("RawOrigin")
 	}
-
-	return o.VaryingData[1].(Address32)
+	return o.VaryingData[1].(Address32), nil
 }

--- a/primitives/types/raw_origin_test.go
+++ b/primitives/types/raw_origin_test.go
@@ -10,7 +10,7 @@ import (
 
 var (
 	bytesAddress, _ = hex.DecodeString("0000000000000000000000000000000000000000000000000000000000000000")
-	address         = NewAddress32(sc.BytesToSequenceU8(bytesAddress)...)
+	address, _      = NewAddress32(sc.BytesToSequenceU8(bytesAddress)...)
 
 	signedOrigin = NewRawOriginSigned(address)
 )
@@ -68,19 +68,24 @@ func Test_RawOrigin_IsNoneOrigin(t *testing.T) {
 }
 
 func Test_RawOrigin_AsSigned(t *testing.T) {
-	result := signedOrigin.AsSigned()
+	result, err := signedOrigin.AsSigned()
 
+	assert.NoError(t, err)
 	assert.Equal(t, address, result)
 }
 
-func Test_RawOrigin_AsSigned_Panics(t *testing.T) {
-	expectErr := "not a signed origin"
+func Test_RawOriginRoot_AsSigned_TypeError(t *testing.T) {
+	address, err := NewRawOriginRoot().AsSigned()
 
-	assert.PanicsWithValue(t, expectErr, func() {
-		NewRawOriginRoot().AsSigned()
-	})
+	assert.Error(t, err)
+	assert.Equal(t, "not a valid 'RawOrigin' type", err.Error())
+	assert.Equal(t, Address32{}, address)
+}
 
-	assert.PanicsWithValue(t, expectErr, func() {
-		NewRawOriginNone().AsSigned()
-	})
+func Test_RawOriginNone_AsSigned_TypeError(t *testing.T) {
+	address, err := NewRawOriginNone().AsSigned()
+
+	assert.Error(t, err)
+	assert.Equal(t, "not a valid 'RawOrigin' type", err.Error())
+	assert.Equal(t, Address32{}, address)
 }

--- a/primitives/types/runtime_dispatch_info_test.go
+++ b/primitives/types/runtime_dispatch_info_test.go
@@ -33,7 +33,7 @@ func Test_DecodeRuntimeDispatchInfo(t *testing.T) {
 	buffer := bytes.NewBuffer(expectBytesRuntimeDispatchInfo)
 
 	result, err := DecodeRuntimeDispatchInfo(buffer)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, runtimeDispatchInfo, result)
 }

--- a/primitives/types/runtime_version_test.go
+++ b/primitives/types/runtime_version_test.go
@@ -66,7 +66,7 @@ func Test_DecodeRuntimeVersion(t *testing.T) {
 	buffer := bytes.NewBuffer(expectBytesRuntimeVersion)
 
 	result, err := DecodeRuntimeVersion(buffer)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, runtimeVersion, result)
 }

--- a/primitives/types/testextra_test.go
+++ b/primitives/types/testextra_test.go
@@ -6,6 +6,10 @@ import (
 	sc "github.com/LimeChain/goscale"
 )
 
+var (
+	unknownTransactionCustomUnknownTransaction, _ = NewTransactionValidityError(NewUnknownTransactionCustomUnknownTransaction(sc.U8(0)))
+)
+
 type testExtraCheck struct {
 	hasError sc.Bool
 	value    sc.U32
@@ -43,7 +47,7 @@ func (e *testExtraCheck) Decode(buffer *bytes.Buffer) error {
 
 func (e testExtraCheck) AdditionalSigned() (AdditionalSigned, TransactionValidityError) {
 	if e.hasError {
-		return nil, NewTransactionValidityError(NewUnknownTransactionCustomUnknownTransaction(sc.U8(0)))
+		return nil, unknownTransactionCustomUnknownTransaction
 	}
 
 	return sc.NewVaryingData(e.value), nil
@@ -54,7 +58,7 @@ func (e testExtraCheck) Validate(who Address32, call Call, info *DispatchInfo, l
 	validTransaction.Priority = 1
 
 	if e.hasError {
-		return ValidTransaction{}, NewTransactionValidityError(NewUnknownTransactionCustomUnknownTransaction(sc.U8(0)))
+		return ValidTransaction{}, unknownTransactionCustomUnknownTransaction
 	}
 
 	return validTransaction, nil
@@ -76,7 +80,7 @@ func (e testExtraCheck) PreDispatchUnsigned(call Call, info *DispatchInfo, lengt
 
 func (e testExtraCheck) PostDispatch(pre sc.Option[Pre], info *DispatchInfo, postInfo *PostDispatchInfo, length sc.Compact, result *DispatchResult) TransactionValidityError {
 	if e.hasError {
-		return NewTransactionValidityError(NewUnknownTransactionCustomUnknownTransaction(sc.U8(0)))
+		return unknownTransactionCustomUnknownTransaction
 	}
 
 	return nil

--- a/primitives/types/timestamp_error.go
+++ b/primitives/types/timestamp_error.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	sc "github.com/LimeChain/goscale"
-	"github.com/LimeChain/gosemble/primitives/log"
 )
 
 const (
@@ -45,8 +44,6 @@ func (te TimestampError) Error() string {
 	case TimestampErrorInvalid:
 		return "invalid inherent check for timestamp module"
 	default:
-		log.Critical("invalid TimestampError")
+		return NewTypeError("TimestampError").Error()
 	}
-
-	panic("unreachable")
 }

--- a/primitives/types/timestamp_error.go
+++ b/primitives/types/timestamp_error.go
@@ -44,6 +44,6 @@ func (te TimestampError) Error() string {
 	case TimestampErrorInvalid:
 		return "invalid inherent check for timestamp module"
 	default:
-		return NewTypeError("TimestampError").Error()
+		return newTypeError("TimestampError").Error()
 	}
 }

--- a/primitives/types/timestamp_error_test.go
+++ b/primitives/types/timestamp_error_test.go
@@ -50,10 +50,10 @@ func Test_TimestampError_Error_Invalid(t *testing.T) {
 	assert.Equal(t, "invalid inherent check for timestamp module", target.Error())
 }
 
-func Test_TimestampError_Error_Panics(t *testing.T) {
+func Test_TimestampError_Error_TypeError(t *testing.T) {
 	target := TimestampError{sc.NewVaryingData(sc.U8(3))}
 
-	assert.PanicsWithValue(t, "invalid TimestampError", func() {
-		target.Error()
-	})
+	err := target.Error()
+
+	assert.Equal(t, "not a valid 'TimestampError' type", err)
 }

--- a/primitives/types/token_error.go
+++ b/primitives/types/token_error.go
@@ -3,8 +3,6 @@ package types
 import (
 	"bytes"
 
-	"github.com/LimeChain/gosemble/primitives/log"
-
 	sc "github.com/LimeChain/goscale"
 )
 
@@ -51,7 +49,7 @@ func NewTokenErrorUnsupported() TokenError {
 func DecodeTokenError(buffer *bytes.Buffer) (TokenError, error) {
 	b, err := sc.DecodeU8(buffer)
 	if err != nil {
-		return TokenError{}, err
+		return nil, err
 	}
 
 	switch b {
@@ -70,8 +68,6 @@ func DecodeTokenError(buffer *bytes.Buffer) (TokenError, error) {
 	case TokenErrorUnsupported:
 		return NewTokenErrorUnsupported(), nil
 	default:
-		log.Critical("invalid TokenError type")
+		return nil, NewTypeError("TokenError")
 	}
-
-	panic("unreachable")
 }

--- a/primitives/types/token_error.go
+++ b/primitives/types/token_error.go
@@ -68,6 +68,6 @@ func DecodeTokenError(buffer *bytes.Buffer) (TokenError, error) {
 	case TokenErrorUnsupported:
 		return NewTokenErrorUnsupported(), nil
 	default:
-		return nil, NewTypeError("TokenError")
+		return nil, newTypeError("TokenError")
 	}
 }

--- a/primitives/types/token_error_test.go
+++ b/primitives/types/token_error_test.go
@@ -106,11 +106,13 @@ func Test_DecodeTokenError_Unsupported(t *testing.T) {
 	assert.Equal(t, NewTokenErrorUnsupported(), result)
 }
 
-func Test_DecodeTokenError_Panics(t *testing.T) {
+func Test_DecodeTokenError_TypeError(t *testing.T) {
 	buffer := &bytes.Buffer{}
 	buffer.WriteByte(7)
 
-	assert.PanicsWithValue(t, "invalid TokenError type", func() {
-		DecodeTokenError(buffer)
-	})
+	res, err := DecodeTokenError(buffer)
+
+	assert.Error(t, err)
+	assert.Equal(t, "not a valid 'TokenError' type", err.Error())
+	assert.Nil(t, res)
 }

--- a/primitives/types/transaction_source.go
+++ b/primitives/types/transaction_source.go
@@ -62,6 +62,6 @@ func DecodeTransactionSource(buffer *bytes.Buffer) (TransactionSource, error) {
 	case TransactionSourceExternal:
 		return NewTransactionSourceExternal(), nil
 	default:
-		return TransactionSource{}, NewTypeError("TransactionSource")
+		return TransactionSource{}, newTypeError("TransactionSource")
 	}
 }

--- a/primitives/types/transaction_source.go
+++ b/primitives/types/transaction_source.go
@@ -3,8 +3,6 @@ package types
 import (
 	"bytes"
 
-	"github.com/LimeChain/gosemble/primitives/log"
-
 	sc "github.com/LimeChain/goscale"
 )
 
@@ -64,8 +62,6 @@ func DecodeTransactionSource(buffer *bytes.Buffer) (TransactionSource, error) {
 	case TransactionSourceExternal:
 		return NewTransactionSourceExternal(), nil
 	default:
-		log.Critical("invalid TransactionSource type")
+		return TransactionSource{}, NewTypeError("TransactionSource")
 	}
-
-	panic("unreachable")
 }

--- a/primitives/types/transaction_source_test.go
+++ b/primitives/types/transaction_source_test.go
@@ -47,11 +47,13 @@ func Test_DecodeTransactionSource_External(t *testing.T) {
 	assert.Equal(t, NewTransactionSourceExternal(), txSource)
 }
 
-func Test_DecodeTransactionSource_Panics(t *testing.T) {
+func Test_DecodeTransactionSource_TypeError(t *testing.T) {
 	buffer := &bytes.Buffer{}
 	buffer.WriteByte(3)
 
-	assert.PanicsWithValue(t, "invalid TransactionSource type", func() {
-		DecodeTransactionSource(buffer)
-	})
+	result, err := DecodeTransactionSource(buffer)
+
+	assert.Error(t, err)
+	assert.Equal(t, "not a valid 'TransactionSource' type", err.Error())
+	assert.Equal(t, TransactionSource{}, result)
 }

--- a/primitives/types/transaction_validity_error.go
+++ b/primitives/types/transaction_validity_error.go
@@ -8,8 +8,8 @@ import (
 	"github.com/LimeChain/gosemble/primitives/log"
 )
 
-const (
-	errInvalidTransactionValidityErrorType = "invalid TransactionValidityError type"
+var (
+	errInvalidTransactionValidityErrorType = NewTypeError("TransactionValidityError")
 )
 
 const (
@@ -20,16 +20,15 @@ const (
 // TransactionValidityError Errors that can occur while checking the validity of a transaction.
 type TransactionValidityError sc.VaryingData
 
-func NewTransactionValidityError(value sc.Encodable) TransactionValidityError {
+func NewTransactionValidityError(value sc.Encodable) (TransactionValidityError, error) {
 	// InvalidTransaction = 0 - Transaction is invalid.
 	// UnknownTransaction = 1 - Transaction validity can’t be determined.
 	switch value.(type) {
 	case InvalidTransaction, UnknownTransaction:
 	default:
-		log.Critical(errInvalidTransactionValidityErrorType)
+		return TransactionValidityError{}, errInvalidTransactionValidityErrorType
 	}
-
-	return TransactionValidityError(sc.NewVaryingData(value))
+	return TransactionValidityError(sc.NewVaryingData(value)), nil
 }
 
 func (e TransactionValidityError) Encode(buffer *bytes.Buffer) {
@@ -41,7 +40,7 @@ func (e TransactionValidityError) Encode(buffer *bytes.Buffer) {
 	case reflect.TypeOf(*new(UnknownTransaction)):
 		TransactionValidityErrorUnknownTransaction.Encode(buffer)
 	default:
-		log.Critical(errInvalidTransactionValidityErrorType)
+		log.Critical(errInvalidTransactionValidityErrorType.Error())
 	}
 
 	value.Encode(buffer)
@@ -59,18 +58,16 @@ func DecodeTransactionValidityError(buffer *bytes.Buffer) (TransactionValidityEr
 		if err != nil {
 			return TransactionValidityError{}, err
 		}
-		return NewTransactionValidityError(value), nil
+		return NewTransactionValidityError(value)
 	case TransactionValidityErrorUnknownTransaction:
 		value, err := DecodeUnknownTransaction(buffer)
 		if err != nil {
 			return TransactionValidityError{}, err
 		}
-		return NewTransactionValidityError(value), nil
+		return NewTransactionValidityError(value)
 	default:
-		log.Critical(errInvalidTransactionValidityErrorType)
+		return TransactionValidityError{}, errInvalidTransactionValidityErrorType
 	}
-
-	panic("unreachable")
 }
 
 func (e TransactionValidityError) Bytes() []byte {

--- a/primitives/types/transaction_validity_error.go
+++ b/primitives/types/transaction_validity_error.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	errInvalidTransactionValidityErrorType = NewTypeError("TransactionValidityError")
+	errInvalidTransactionValidityErrorType = newTypeError("TransactionValidityError")
 )
 
 const (

--- a/primitives/types/transaction_validity_error_test.go
+++ b/primitives/types/transaction_validity_error_test.go
@@ -9,10 +9,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_NewTransactionValidityError_Panics(t *testing.T) {
-	assert.PanicsWithValue(t, errInvalidTransactionValidityErrorType, func() {
-		NewTransactionValidityError(sc.U8(6))
-	})
+var (
+	unknownTransactionCannotLookup, _ = NewTransactionValidityError(NewUnknownTransactionCannotLookup())
+)
+
+func Test_NewTransactionValidityError_TypeError(t *testing.T) {
+	result, err := NewTransactionValidityError(sc.U8(6))
+
+	assert.Error(t, err)
+	assert.Equal(t, "not a valid 'TransactionValidityError' type", err.Error())
+	assert.Equal(t, TransactionValidityError{}, result)
 }
 
 func Test_TransactionValidityError_Encode(t *testing.T) {
@@ -23,12 +29,12 @@ func Test_TransactionValidityError_Encode(t *testing.T) {
 	}{
 		{
 			label:       "Encode(TransactionValidityError(InvalidTransaction(PaymentError)))",
-			input:       NewTransactionValidityError(NewInvalidTransactionPayment()),
+			input:       invalidTransactionPayment,
 			expectation: []byte{0x00, 0x01},
 		},
 		{
 			label:       "Encode(TransactionValidityError(UnknownTransaction(0)))",
-			input:       NewTransactionValidityError(NewUnknownTransactionCannotLookup()),
+			input:       unknownTransactionCannotLookup,
 			expectation: []byte{0x01, 0x00},
 		},
 	}
@@ -47,7 +53,7 @@ func Test_TransactionValidityError_Encode(t *testing.T) {
 func Test_TransactionValidityError_Encode_Panics(t *testing.T) {
 	buffer := &bytes.Buffer{}
 
-	assert.PanicsWithValue(t, errInvalidTransactionValidityErrorType, func() {
+	assert.PanicsWithValue(t, "not a valid 'TransactionValidityError' type", func() {
 		tve := TransactionValidityError(sc.NewVaryingData(sc.U8(6)))
 
 		tve.Encode(buffer)
@@ -65,12 +71,12 @@ func Test_DecodeTransactionValidityError(t *testing.T) {
 		{
 			label:       "Encode(TransactionValidityError(InvalidTransaction(PaymentError)))",
 			input:       []byte{0x00, 0x01},
-			expectation: NewTransactionValidityError(NewInvalidTransactionPayment()),
+			expectation: invalidTransactionPayment,
 		},
 		{
 			label:       "Encode(TransactionValidityError(UnknownTransaction(0)))",
 			input:       []byte{0x01, 0x00},
-			expectation: NewTransactionValidityError(NewUnknownTransactionCannotLookup()),
+			expectation: unknownTransactionCannotLookup,
 		},
 	}
 
@@ -87,18 +93,20 @@ func Test_DecodeTransactionValidityError(t *testing.T) {
 	}
 }
 
-func Test_DecodeTransactionValidityError_Panics(t *testing.T) {
+func Test_DecodeTransactionValidityError_TypeError(t *testing.T) {
 	buffer := &bytes.Buffer{}
 	buffer.WriteByte(6)
 
-	assert.PanicsWithValue(t, errInvalidTransactionValidityErrorType, func() {
-		DecodeTransactionValidityError(buffer)
-	})
+	res, err := DecodeTransactionValidityError(buffer)
+
+	assert.Error(t, err)
+	assert.Equal(t, "not a valid 'TransactionValidityError' type", err.Error())
+	assert.Equal(t, TransactionValidityError{}, res)
+
 }
 
 func Test_TransactionValidityError_Bytes(t *testing.T) {
 	expect, _ := hex.DecodeString("0001")
-	tve := NewTransactionValidityError(NewInvalidTransactionPayment())
 
-	assert.Equal(t, expect, tve.Bytes())
+	assert.Equal(t, expect, invalidTransactionPayment.Bytes())
 }

--- a/primitives/types/transaction_validity_result.go
+++ b/primitives/types/transaction_validity_result.go
@@ -24,7 +24,7 @@ func NewTransactionValidityResult(value sc.Encodable) (TransactionValidityResult
 	case ValidTransaction, TransactionValidityError:
 		return TransactionValidityResult(sc.NewVaryingData(value)), nil
 	default:
-		return TransactionValidityResult{}, NewTypeError("TransactionValidityResult")
+		return TransactionValidityResult{}, newTypeError("TransactionValidityResult")
 	}
 }
 
@@ -61,7 +61,7 @@ func DecodeTransactionValidityResult(buffer *bytes.Buffer) (TransactionValidityR
 		}
 		return NewTransactionValidityResult(val)
 	default:
-		return TransactionValidityResult{}, NewTypeError("TransactionValidityResult")
+		return TransactionValidityResult{}, newTypeError("TransactionValidityResult")
 	}
 }
 
@@ -82,6 +82,6 @@ func (r TransactionValidityResult) AsValidTransaction() (ValidTransaction, error
 	if r.IsValidTransaction() {
 		return r[0].(ValidTransaction), nil
 	} else {
-		return ValidTransaction{}, NewTypeError("ValidTransaction")
+		return ValidTransaction{}, newTypeError("ValidTransaction")
 	}
 }

--- a/primitives/types/transaction_validity_result.go
+++ b/primitives/types/transaction_validity_result.go
@@ -19,15 +19,13 @@ const (
 // TransactionValidityResult Information on a transaction's validity and, if valid, on how it relates to other transactions.
 type TransactionValidityResult sc.VaryingData
 
-func NewTransactionValidityResult(value sc.Encodable) TransactionValidityResult {
+func NewTransactionValidityResult(value sc.Encodable) (TransactionValidityResult, error) {
 	switch value.(type) {
 	case ValidTransaction, TransactionValidityError:
-		return TransactionValidityResult(sc.NewVaryingData(value))
+		return TransactionValidityResult(sc.NewVaryingData(value)), nil
 	default:
-		log.Critical(errInvalidTransactionValidityResultType)
+		return TransactionValidityResult{}, NewTypeError("TransactionValidityResult")
 	}
-
-	panic("unreachable")
 }
 
 func (r TransactionValidityResult) Encode(buffer *bytes.Buffer) {
@@ -55,18 +53,16 @@ func DecodeTransactionValidityResult(buffer *bytes.Buffer) (TransactionValidityR
 		if err != nil {
 			return TransactionValidityResult{}, err
 		}
-		return NewTransactionValidityResult(val), nil
+		return NewTransactionValidityResult(val)
 	case TransactionValidityResultError:
 		val, err := DecodeTransactionValidityError(buffer)
 		if err != nil {
 			return TransactionValidityResult{}, err
 		}
-		return NewTransactionValidityResult(val), nil
+		return NewTransactionValidityResult(val)
 	default:
-		log.Critical(errInvalidTransactionValidityResultType)
+		return TransactionValidityResult{}, NewTypeError("TransactionValidityResult")
 	}
-
-	panic("unreachable")
 }
 
 func (r TransactionValidityResult) Bytes() []byte {
@@ -82,12 +78,10 @@ func (r TransactionValidityResult) IsValidTransaction() bool {
 	}
 }
 
-func (r TransactionValidityResult) AsValidTransaction() ValidTransaction {
+func (r TransactionValidityResult) AsValidTransaction() (ValidTransaction, error) {
 	if r.IsValidTransaction() {
-		return r[0].(ValidTransaction)
+		return r[0].(ValidTransaction), nil
 	} else {
-		log.Critical("not a ValidTransaction type")
+		return ValidTransaction{}, NewTypeError("ValidTransaction")
 	}
-
-	panic("unreachable")
 }

--- a/primitives/types/transactional_error.go
+++ b/primitives/types/transactional_error.go
@@ -35,6 +35,6 @@ func DecodeTransactionalError(buffer *bytes.Buffer) (TransactionalError, error) 
 	case TransactionalErrorNoLayer:
 		return NewTransactionalErrorNoLayer(), nil
 	default:
-		return nil, NewTypeError("TransactionalError")
+		return nil, newTypeError("TransactionalError")
 	}
 }

--- a/primitives/types/transactional_error.go
+++ b/primitives/types/transactional_error.go
@@ -3,8 +3,6 @@ package types
 import (
 	"bytes"
 
-	"github.com/LimeChain/gosemble/primitives/log"
-
 	sc "github.com/LimeChain/goscale"
 )
 
@@ -37,8 +35,6 @@ func DecodeTransactionalError(buffer *bytes.Buffer) (TransactionalError, error) 
 	case TransactionalErrorNoLayer:
 		return NewTransactionalErrorNoLayer(), nil
 	default:
-		log.Critical("invalid TransactionalError type")
+		return nil, NewTypeError("TransactionalError")
 	}
-
-	panic("unreachable")
 }

--- a/primitives/types/transactional_error_test.go
+++ b/primitives/types/transactional_error_test.go
@@ -36,11 +36,13 @@ func Test_DecodeTransactionalError_NoLayer(t *testing.T) {
 	assert.Equal(t, NewTransactionalErrorNoLayer(), result)
 }
 
-func Test_DecodeTransactionalError_Panics(t *testing.T) {
+func Test_DecodeTransactionalError_TypeError(t *testing.T) {
 	buffer := &bytes.Buffer{}
 	buffer.WriteByte(5)
 
-	assert.PanicsWithValue(t, "invalid TransactionalError type", func() {
-		DecodeTransactionalError(buffer)
-	})
+	res, err := DecodeTransactionalError(buffer)
+
+	assert.Error(t, err)
+	assert.Equal(t, "not a valid 'TransactionalError' type", err.Error())
+	assert.Nil(t, res)
 }

--- a/primitives/types/unknown_transaction.go
+++ b/primitives/types/unknown_transaction.go
@@ -51,6 +51,6 @@ func DecodeUnknownTransaction(buffer *bytes.Buffer) (UnknownTransaction, error) 
 		}
 		return NewUnknownTransactionCustomUnknownTransaction(v), nil
 	default:
-		return UnknownTransaction{}, NewTypeError("UnknownTransaction")
+		return UnknownTransaction{}, newTypeError("UnknownTransaction")
 	}
 }

--- a/primitives/types/unknown_transaction.go
+++ b/primitives/types/unknown_transaction.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 
 	sc "github.com/LimeChain/goscale"
-	"github.com/LimeChain/gosemble/primitives/log"
 )
 
 const (
@@ -52,8 +51,6 @@ func DecodeUnknownTransaction(buffer *bytes.Buffer) (UnknownTransaction, error) 
 		}
 		return NewUnknownTransactionCustomUnknownTransaction(v), nil
 	default:
-		log.Critical("invalid UnknownTransaction type")
+		return UnknownTransaction{}, NewTypeError("UnknownTransaction")
 	}
-
-	panic("unreachable")
 }

--- a/primitives/types/unknown_transaction_test.go
+++ b/primitives/types/unknown_transaction_test.go
@@ -55,11 +55,13 @@ func Test_DecodeUnknownTransaction_CustomUnknownTransaction(t *testing.T) {
 	assert.Equal(t, NewUnknownTransactionCustomUnknownTransaction(unknownTxId), result)
 }
 
-func Test_DecodeUnknownTransaction_Panics(t *testing.T) {
+func Test_DecodeUnknownTransaction_TypeError(t *testing.T) {
 	buffer := &bytes.Buffer{}
 	buffer.WriteByte(5)
 
-	assert.PanicsWithValue(t, "invalid UnknownTransaction type", func() {
-		DecodeUnknownTransaction(buffer)
-	})
+	res, err := DecodeUnknownTransaction(buffer)
+
+	assert.Error(t, err)
+	assert.Equal(t, "not a valid 'UnknownTransaction' type", err.Error())
+	assert.Equal(t, UnknownTransaction{}, res)
 }

--- a/runtime/balances_force_free_test.go
+++ b/runtime/balances_force_free_test.go
@@ -7,7 +7,6 @@ import (
 
 	gossamertypes "github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/pkg/scale"
-	primitives "github.com/LimeChain/gosemble/primitives/types"
 	cscale "github.com/centrifuge/go-substrate-rpc-client/v4/scale"
 	"github.com/centrifuge/go-substrate-rpc-client/v4/signature"
 	ctypes "github.com/centrifuge/go-substrate-rpc-client/v4/types"
@@ -63,10 +62,5 @@ func Test_Balances_ForceFree_BadOrigin(t *testing.T) {
 	res, err := rt.Exec("BlockBuilder_apply_extrinsic", extEnc.Bytes())
 	assert.NoError(t, err)
 
-	expectedResult :=
-		primitives.NewApplyExtrinsicResult(
-			primitives.NewDispatchOutcome(
-				primitives.NewDispatchErrorBadOrigin()))
-
-	assert.Equal(t, expectedResult.Bytes(), res)
+	assert.Equal(t, applyExtrinsicResultBadOriginErr.Bytes(), res)
 }

--- a/runtime/balances_force_transfer_test.go
+++ b/runtime/balances_force_transfer_test.go
@@ -7,7 +7,6 @@ import (
 
 	gossamertypes "github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/pkg/scale"
-	primitives "github.com/LimeChain/gosemble/primitives/types"
 	cscale "github.com/centrifuge/go-substrate-rpc-client/v4/scale"
 	"github.com/centrifuge/go-substrate-rpc-client/v4/signature"
 	ctypes "github.com/centrifuge/go-substrate-rpc-client/v4/types"
@@ -67,10 +66,5 @@ func Test_Balances_ForceTransfer_BadOrigin(t *testing.T) {
 	res, err := rt.Exec("BlockBuilder_apply_extrinsic", extEnc.Bytes())
 	assert.NoError(t, err)
 
-	expectedResult :=
-		primitives.NewApplyExtrinsicResult(
-			primitives.NewDispatchOutcome(
-				primitives.NewDispatchErrorBadOrigin()))
-
-	assert.Equal(t, expectedResult.Bytes(), res)
+	assert.Equal(t, applyExtrinsicResultBadOriginErr.Bytes(), res)
 }

--- a/runtime/balances_set_balance_test.go
+++ b/runtime/balances_set_balance_test.go
@@ -7,7 +7,6 @@ import (
 
 	gossamertypes "github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/pkg/scale"
-	primitives "github.com/LimeChain/gosemble/primitives/types"
 	cscale "github.com/centrifuge/go-substrate-rpc-client/v4/scale"
 	"github.com/centrifuge/go-substrate-rpc-client/v4/signature"
 	ctypes "github.com/centrifuge/go-substrate-rpc-client/v4/types"
@@ -65,10 +64,5 @@ func Test_Balances_SetBalance_BadOrigin(t *testing.T) {
 	res, err := rt.Exec("BlockBuilder_apply_extrinsic", extEnc.Bytes())
 	assert.NoError(t, err)
 
-	expectedResult :=
-		primitives.NewApplyExtrinsicResult(
-			primitives.NewDispatchOutcome(
-				primitives.NewDispatchErrorBadOrigin()))
-
-	assert.Equal(t, expectedResult.Bytes(), res)
+	assert.Equal(t, applyExtrinsicResultBadOriginErr.Bytes(), res)
 }

--- a/runtime/balances_transfer_all_test.go
+++ b/runtime/balances_transfer_all_test.go
@@ -8,9 +8,6 @@ import (
 	gossamertypes "github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/pkg/scale"
-	sc "github.com/LimeChain/goscale"
-	"github.com/LimeChain/gosemble/frame/balances"
-	primitives "github.com/LimeChain/gosemble/primitives/types"
 	cscale "github.com/centrifuge/go-substrate-rpc-client/v4/scale"
 	"github.com/centrifuge/go-substrate-rpc-client/v4/signature"
 	ctypes "github.com/centrifuge/go-substrate-rpc-client/v4/types"
@@ -69,10 +66,7 @@ func Test_Balances_TransferAll_Success_AllowDeath(t *testing.T) {
 
 	res, err := rt.Exec("BlockBuilder_apply_extrinsic", extEnc.Bytes())
 	assert.NoError(t, err)
-	assert.Equal(t,
-		primitives.NewApplyExtrinsicResult(primitives.NewDispatchOutcome(nil)).Bytes(),
-		res,
-	)
+	assert.Equal(t, applyExtrinsicResultOutcome.Bytes(), res)
 
 	bobHash, _ := common.Blake2b128(bob.AsID[:])
 	keyStorageAccountBob := append(keySystemHash, keyAccountHash...)
@@ -172,19 +166,7 @@ func Test_Balances_TransferAll_Success_KeepAlive(t *testing.T) {
 	assert.NoError(t, err)
 
 	// TODO: remove once tx payments are implemented
-	expectedResult :=
-		primitives.NewApplyExtrinsicResult(
-			primitives.NewDispatchOutcome(
-				primitives.NewDispatchErrorModule(
-					primitives.CustomModuleError{
-						Index: BalancesIndex,
-						Error: sc.U32(balances.ErrorKeepAlive),
-					})))
-
-	assert.Equal(t,
-		expectedResult.Bytes(),
-		res,
-	)
+	assert.Equal(t, applyExtrinsicResultKeepAliveErr.Bytes(), res)
 
 	// TODO: Uncomment once tx payments are implemented, this will be successfully executed,
 	// for now it fails due to nothing reserved in account executor

--- a/runtime/balances_transfer_keep_alive_test.go
+++ b/runtime/balances_transfer_keep_alive_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/pkg/scale"
 	"github.com/LimeChain/gosemble/constants"
-	primitives "github.com/LimeChain/gosemble/primitives/types"
 	cscale "github.com/centrifuge/go-substrate-rpc-client/v4/scale"
 	"github.com/centrifuge/go-substrate-rpc-client/v4/signature"
 	ctypes "github.com/centrifuge/go-substrate-rpc-client/v4/types"
@@ -71,10 +70,7 @@ func Test_Balances_TransferKeepAlive_Success(t *testing.T) {
 	res, err := rt.Exec("BlockBuilder_apply_extrinsic", extEnc.Bytes())
 	assert.NoError(t, err)
 
-	assert.Equal(t,
-		primitives.NewApplyExtrinsicResult(primitives.NewDispatchOutcome(nil)).Bytes(),
-		res,
-	)
+	assert.Equal(t, applyExtrinsicResultOutcome.Bytes(), res)
 
 	bobHash, _ := common.Blake2b128(bob.AsID[:])
 	keyStorageAccountBob := append(keySystemHash, keyAccountHash...)

--- a/runtime/balances_transfer_test.go
+++ b/runtime/balances_transfer_test.go
@@ -8,10 +8,7 @@ import (
 	gossamertypes "github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/pkg/scale"
-	sc "github.com/LimeChain/goscale"
 	"github.com/LimeChain/gosemble/constants"
-	"github.com/LimeChain/gosemble/frame/balances"
-	primitives "github.com/LimeChain/gosemble/primitives/types"
 	cscale "github.com/centrifuge/go-substrate-rpc-client/v4/scale"
 	"github.com/centrifuge/go-substrate-rpc-client/v4/signature"
 	ctypes "github.com/centrifuge/go-substrate-rpc-client/v4/types"
@@ -72,10 +69,7 @@ func Test_Balances_Transfer_Success(t *testing.T) {
 
 	res, err := rt.Exec("BlockBuilder_apply_extrinsic", extEnc.Bytes())
 	assert.NoError(t, err)
-	assert.Equal(t,
-		primitives.NewApplyExtrinsicResult(primitives.NewDispatchOutcome(nil)).Bytes(),
-		res,
-	)
+	assert.Equal(t, applyExtrinsicResultOutcome.Bytes(), res)
 
 	bobHash, _ := common.Blake2b128(bob.AsID[:])
 	keyStorageAccountBob := append(keySystemHash, keyAccountHash...)
@@ -176,16 +170,7 @@ func Test_Balances_Transfer_Invalid_InsufficientBalance(t *testing.T) {
 	assert.NoError(t, err)
 
 	res, err := rt.Exec("BlockBuilder_apply_extrinsic", extEnc.Bytes())
-	expectedResult :=
-		primitives.NewApplyExtrinsicResult(
-			primitives.NewDispatchOutcome(
-				primitives.NewDispatchErrorModule(
-					primitives.CustomModuleError{
-						Index: BalancesIndex,
-						Error: sc.U32(balances.ErrorInsufficientBalance),
-					})))
-
-	assert.Equal(t, expectedResult.Bytes(), res)
+	assert.Equal(t, applyExtrinsicResultCustomModuleErr.Bytes(), res)
 }
 
 func Test_Balances_Transfer_Invalid_ExistentialDeposit(t *testing.T) {
@@ -239,14 +224,5 @@ func Test_Balances_Transfer_Invalid_ExistentialDeposit(t *testing.T) {
 	res, err := rt.Exec("BlockBuilder_apply_extrinsic", extEnc.Bytes())
 	assert.NoError(t, err)
 
-	expectedResult :=
-		primitives.NewApplyExtrinsicResult(
-			primitives.NewDispatchOutcome(
-				primitives.NewDispatchErrorModule(
-					primitives.CustomModuleError{
-						Index: BalancesIndex,
-						Error: sc.U32(balances.ErrorExistentialDeposit),
-					})))
-
-	assert.Equal(t, expectedResult.Bytes(), res)
+	assert.Equal(t, applyExtrinsicResultExistentialDepositErr.Bytes(), res)
 }

--- a/runtime/block_builder_apply_extrinsic_test.go
+++ b/runtime/block_builder_apply_extrinsic_test.go
@@ -64,7 +64,7 @@ func Test_ApplyExtrinsic_Timestamp(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t,
-		primitives.NewApplyExtrinsicResult(primitives.NewDispatchOutcome(nil)).Bytes(),
+		applyExtrinsicResultOutcome.Bytes(),
 		applyResult,
 	)
 
@@ -139,11 +139,7 @@ func Test_ApplyExtrinsic_DispatchOutcome(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, expectedExtrinsicDataStorage, storageUxt)
-
-	assert.Equal(t,
-		primitives.NewApplyExtrinsicResult(primitives.NewDispatchOutcome(nil)).Bytes(),
-		res,
-	)
+	assert.Equal(t, applyExtrinsicResultOutcome.Bytes(), res)
 }
 
 func Test_ApplyExtrinsic_Unsigned_DispatchOutcome(t *testing.T) {
@@ -163,14 +159,7 @@ func Test_ApplyExtrinsic_Unsigned_DispatchOutcome(t *testing.T) {
 	res, err := rt.Exec("BlockBuilder_apply_extrinsic", extEnc.Bytes())
 	assert.NoError(t, err)
 
-	assert.Equal(
-		t,
-		primitives.NewApplyExtrinsicResult(
-			primitives.NewDispatchOutcome(
-				primitives.NewDispatchErrorBadOrigin())).
-			Bytes(),
-		res,
-	)
+	assert.Equal(t, applyExtrinsicResultBadOriginErr.Bytes(), res)
 }
 
 func Test_ApplyExtrinsic_DispatchError_BadProofError(t *testing.T) {
@@ -222,12 +211,7 @@ func Test_ApplyExtrinsic_DispatchError_BadProofError(t *testing.T) {
 	extrinsicIndexValue := (*storage).Get(append(keySystemHash, sc.NewOption[sc.U32](extrinsicIndex).Bytes()...))
 	assert.Equal(t, []byte(nil), extrinsicIndexValue)
 
-	assert.Equal(t,
-		primitives.NewApplyExtrinsicResult(
-			primitives.NewTransactionValidityError(primitives.NewInvalidTransactionBadProof()),
-		).Bytes(),
-		res,
-	)
+	assert.Equal(t, applyExtrinsicResultBadProofErr.Bytes(), res)
 }
 
 func Test_ApplyExtrinsic_ExhaustsResourcesError(t *testing.T) {
@@ -279,13 +263,7 @@ func Test_ApplyExtrinsic_ExhaustsResourcesError(t *testing.T) {
 	extrinsicIndexValue := (*storage).Get(append(keySystemHash, sc.NewOption[sc.U32](extrinsicIndex).Bytes()...))
 	assert.Equal(t, []byte(nil), extrinsicIndexValue)
 
-	assert.Equal(t,
-		primitives.NewApplyExtrinsicResult(
-			primitives.NewTransactionValidityError(
-				primitives.NewInvalidTransactionExhaustsResources()),
-		).Bytes(),
-		res,
-	)
+	assert.Equal(t, applyExtrinsicResultExhaustsResourcesErr.Bytes(), res)
 }
 
 func Test_ApplyExtrinsic_FutureError_InvalidNonce(t *testing.T) {
@@ -337,14 +315,8 @@ func Test_ApplyExtrinsic_FutureError_InvalidNonce(t *testing.T) {
 	buffer.Write(encTransactionValidityResult)
 	transactionValidityResult, err := primitives.DecodeTransactionValidityResult(buffer)
 	assert.Nil(t, err)
-	assert.Equal(t,
-		primitives.NewTransactionValidityResult(
-			primitives.NewTransactionValidityError(
-				primitives.NewInvalidTransactionFuture(),
-			),
-		),
-		transactionValidityResult,
-	)
+
+	assert.Equal(t, transactionValidityResultFutureErr, transactionValidityResult)
 }
 
 func Test_ApplyExtrinsic_InvalidLengthPrefix(t *testing.T) {

--- a/runtime/core_execute_block_test.go
+++ b/runtime/core_execute_block_test.go
@@ -118,7 +118,7 @@ func Test_BlockExecution(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t,
-		primitives.NewApplyExtrinsicResult(primitives.NewDispatchOutcome(nil)).Bytes(),
+		applyExtrinsicResultOutcome.Bytes(),
 		applyResult,
 	)
 

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -30,6 +30,7 @@ import (
 	"github.com/LimeChain/gosemble/frame/transaction_payment"
 	txExtensions "github.com/LimeChain/gosemble/frame/transaction_payment/extensions"
 	"github.com/LimeChain/gosemble/hooks"
+	"github.com/LimeChain/gosemble/primitives/log"
 	primitives "github.com/LimeChain/gosemble/primitives/types"
 )
 
@@ -135,11 +136,50 @@ func initializeModules() []primitives.Module {
 	}
 }
 
+func getSystemModule() system.Module {
+	mod, err := primitives.MustGetModule(SystemIndex, modules)
+	if err != nil {
+		log.Critical(err.Error())
+	}
+	return mod.(system.Module)
+}
+
+func getBalancesModule() balances.Module {
+	mod, err := primitives.MustGetModule(BalancesIndex, modules)
+	if err != nil {
+		log.Critical(err.Error())
+	}
+	return mod.(balances.Module)
+}
+
+func getTxPaymentModule() transaction_payment.Module {
+	mod, err := primitives.MustGetModule(TxPaymentsIndex, modules)
+	if err != nil {
+		log.Critical(err.Error())
+	}
+	return mod.(transaction_payment.Module)
+}
+
+func getAuraModule() aura.Module {
+	mod, err := primitives.MustGetModule(AuraIndex, modules)
+	if err != nil {
+		log.Critical(err.Error())
+	}
+	return mod.(aura.Module)
+}
+
+func getGrandpaModule() grandpa.Module {
+	mod, err := primitives.MustGetModule(GrandpaIndex, modules)
+	if err != nil {
+		log.Critical(err.Error())
+	}
+	return mod.(grandpa.Module)
+}
+
 func newSignedExtra() primitives.SignedExtra {
-	modules := modules
-	systemModule := primitives.MustGetModule(SystemIndex, modules).(system.Module)
-	balancesModule := primitives.MustGetModule(BalancesIndex, modules).(balances.Module)
-	txPaymentModule := primitives.MustGetModule(TxPaymentsIndex, modules).(transaction_payment.Module)
+	systemModule := getSystemModule()
+	balancesModule := getBalancesModule()
+	txPaymentModule := getTxPaymentModule()
 
 	checkMortality := sysExtensions.NewCheckMortality(systemModule)
 	checkNonce := sysExtensions.NewCheckNonce(systemModule)
@@ -159,14 +199,13 @@ func newSignedExtra() primitives.SignedExtra {
 }
 
 func runtimeApi() types.RuntimeApi {
-	modules := modules
 	extra := newSignedExtra()
 	decoder := types.NewRuntimeDecoder(modules, extra)
 	runtimeExtrinsic := extrinsic.New(modules, extra)
-	systemModule := primitives.MustGetModule(SystemIndex, modules).(system.Module)
-	auraModule := primitives.MustGetModule(AuraIndex, modules).(aura.Module)
-	grandpaModule := primitives.MustGetModule(GrandpaIndex, modules).(grandpa.Module)
-	txPaymentsModule := primitives.MustGetModule(TxPaymentsIndex, modules).(transaction_payment.Module)
+	systemModule := getSystemModule()
+	auraModule := getAuraModule()
+	grandpaModule := getGrandpaModule()
+	txPaymentsModule := getTxPaymentModule()
 
 	executiveModule := executive.New(
 		systemModule,

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -137,7 +137,7 @@ func initializeModules() []primitives.Module {
 }
 
 func getSystemModule() system.Module {
-	mod, err := primitives.MustGetModule(SystemIndex, modules)
+	mod, err := primitives.GetModule(SystemIndex, modules)
 	if err != nil {
 		log.Critical(err.Error())
 	}
@@ -145,7 +145,7 @@ func getSystemModule() system.Module {
 }
 
 func getBalancesModule() balances.Module {
-	mod, err := primitives.MustGetModule(BalancesIndex, modules)
+	mod, err := primitives.GetModule(BalancesIndex, modules)
 	if err != nil {
 		log.Critical(err.Error())
 	}
@@ -153,7 +153,7 @@ func getBalancesModule() balances.Module {
 }
 
 func getTxPaymentModule() transaction_payment.Module {
-	mod, err := primitives.MustGetModule(TxPaymentsIndex, modules)
+	mod, err := primitives.GetModule(TxPaymentsIndex, modules)
 	if err != nil {
 		log.Critical(err.Error())
 	}
@@ -161,7 +161,7 @@ func getTxPaymentModule() transaction_payment.Module {
 }
 
 func getAuraModule() aura.Module {
-	mod, err := primitives.MustGetModule(AuraIndex, modules)
+	mod, err := primitives.GetModule(AuraIndex, modules)
 	if err != nil {
 		log.Critical(err.Error())
 	}
@@ -169,7 +169,7 @@ func getAuraModule() aura.Module {
 }
 
 func getGrandpaModule() grandpa.Module {
-	mod, err := primitives.MustGetModule(GrandpaIndex, modules)
+	mod, err := primitives.GetModule(GrandpaIndex, modules)
 	if err != nil {
 		log.Critical(err.Error())
 	}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -30,7 +30,6 @@ import (
 	"github.com/LimeChain/gosemble/frame/transaction_payment"
 	txExtensions "github.com/LimeChain/gosemble/frame/transaction_payment/extensions"
 	"github.com/LimeChain/gosemble/hooks"
-	"github.com/LimeChain/gosemble/primitives/log"
 	primitives "github.com/LimeChain/gosemble/primitives/types"
 )
 
@@ -136,50 +135,10 @@ func initializeModules() []primitives.Module {
 	}
 }
 
-func getSystemModule() system.Module {
-	mod, err := primitives.GetModule(SystemIndex, modules)
-	if err != nil {
-		log.Critical(err.Error())
-	}
-	return mod.(system.Module)
-}
-
-func getBalancesModule() balances.Module {
-	mod, err := primitives.GetModule(BalancesIndex, modules)
-	if err != nil {
-		log.Critical(err.Error())
-	}
-	return mod.(balances.Module)
-}
-
-func getTxPaymentModule() transaction_payment.Module {
-	mod, err := primitives.GetModule(TxPaymentsIndex, modules)
-	if err != nil {
-		log.Critical(err.Error())
-	}
-	return mod.(transaction_payment.Module)
-}
-
-func getAuraModule() aura.Module {
-	mod, err := primitives.GetModule(AuraIndex, modules)
-	if err != nil {
-		log.Critical(err.Error())
-	}
-	return mod.(aura.Module)
-}
-
-func getGrandpaModule() grandpa.Module {
-	mod, err := primitives.GetModule(GrandpaIndex, modules)
-	if err != nil {
-		log.Critical(err.Error())
-	}
-	return mod.(grandpa.Module)
-}
-
 func newSignedExtra() primitives.SignedExtra {
-	systemModule := getSystemModule()
-	balancesModule := getBalancesModule()
-	txPaymentModule := getTxPaymentModule()
+	systemModule := primitives.MustGetModule(SystemIndex, modules).(system.Module)
+	balancesModule := primitives.MustGetModule(BalancesIndex, modules).(balances.Module)
+	txPaymentModule := primitives.MustGetModule(TxPaymentsIndex, modules).(transaction_payment.Module)
 
 	checkMortality := sysExtensions.NewCheckMortality(systemModule)
 	checkNonce := sysExtensions.NewCheckNonce(systemModule)
@@ -202,10 +161,10 @@ func runtimeApi() types.RuntimeApi {
 	extra := newSignedExtra()
 	decoder := types.NewRuntimeDecoder(modules, extra)
 	runtimeExtrinsic := extrinsic.New(modules, extra)
-	systemModule := getSystemModule()
-	auraModule := getAuraModule()
-	grandpaModule := getGrandpaModule()
-	txPaymentsModule := getTxPaymentModule()
+	systemModule := primitives.MustGetModule(SystemIndex, modules).(system.Module)
+	auraModule := primitives.MustGetModule(AuraIndex, modules).(aura.Module)
+	grandpaModule := primitives.MustGetModule(GrandpaIndex, modules).(grandpa.Module)
+	txPaymentsModule := primitives.MustGetModule(TxPaymentsIndex, modules).(transaction_payment.Module)
 
 	executiveModule := executive.New(
 		systemModule,

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ChainSafe/gossamer/lib/trie"
 	"github.com/ChainSafe/gossamer/pkg/scale"
 	sc "github.com/LimeChain/goscale"
+	"github.com/LimeChain/gosemble/frame/balances"
 	primitives "github.com/LimeChain/gosemble/primitives/types"
 	cscale "github.com/centrifuge/go-substrate-rpc-client/v4/scale"
 	ctypes "github.com/centrifuge/go-substrate-rpc-client/v4/types"
@@ -60,6 +61,56 @@ var (
 			14, 65, 42, 225, 201, 143, 136, 213, 59, 228, 216, 80, 47, 172, 87, 31, 63, 25, 201, 202, 175, 40, 26,
 			103, 51, 25, 36, 30, 12, 80, 149, 166, 131, 173, 52, 49, 98, 4, 8, 138, 54, 164, 189, 134},
 	}
+)
+
+var (
+	invalidTransactionStaleErr, _             = primitives.NewTransactionValidityError(primitives.NewInvalidTransactionStale())
+	invalidTransactionFutureErr, _            = primitives.NewTransactionValidityError(primitives.NewInvalidTransactionFuture())
+	invalidTransactionBadProofErr, _          = primitives.NewTransactionValidityError(primitives.NewInvalidTransactionBadProof())
+	invalidTransactionExhaustsResourcesErr, _ = primitives.NewTransactionValidityError(primitives.NewInvalidTransactionExhaustsResources())
+	unknownTransactionNoUnsignedValidator, _  = primitives.NewTransactionValidityError(primitives.NewUnknownTransactionNoUnsignedValidator())
+	invalidTransactionMandatoryValidation, _  = primitives.NewTransactionValidityError(primitives.NewInvalidTransactionMandatoryValidation())
+)
+
+var (
+	transactionValidityResultStaleErr, _               = primitives.NewTransactionValidityResult(invalidTransactionStaleErr)
+	transactionValidityResultFutureErr, _              = primitives.NewTransactionValidityResult(invalidTransactionFutureErr)
+	transactionValidityResultExhaustsResourcesErr, _   = primitives.NewTransactionValidityResult(invalidTransactionExhaustsResourcesErr)
+	transactionValidityResultNoUnsignedValidatorErr, _ = primitives.NewTransactionValidityResult(unknownTransactionNoUnsignedValidator)
+	transactionValidityResultMandatoryValidationErr, _ = primitives.NewTransactionValidityResult(invalidTransactionMandatoryValidation)
+
+	dispatchOutcome, _             = primitives.NewDispatchOutcome(nil)
+	dispatchOutcomeBadOriginErr, _ = primitives.NewDispatchOutcome(primitives.NewDispatchErrorBadOrigin())
+
+	dispatchOutcomeCustomModuleErr, _ = primitives.NewDispatchOutcome(
+		primitives.NewDispatchErrorModule(
+			primitives.CustomModuleError{
+				Index: BalancesIndex,
+				Error: sc.U32(balances.ErrorInsufficientBalance),
+			}))
+
+	dispatchOutcomeExistentialDepositErr, _ = primitives.NewDispatchOutcome(
+		primitives.NewDispatchErrorModule(
+			primitives.CustomModuleError{
+				Index: BalancesIndex,
+				Error: sc.U32(balances.ErrorExistentialDeposit),
+			}))
+
+	dispatchOutcomeKeepAliveErr, _ = primitives.NewDispatchOutcome(
+		primitives.NewDispatchErrorModule(
+			primitives.CustomModuleError{
+				Index: BalancesIndex,
+				Error: sc.U32(balances.ErrorKeepAlive),
+			}))
+
+	applyExtrinsicResultOutcome, _              = primitives.NewApplyExtrinsicResult(dispatchOutcome)
+	applyExtrinsicResultExhaustsResourcesErr, _ = primitives.NewApplyExtrinsicResult(invalidTransactionExhaustsResourcesErr)
+	applyExtrinsicResultBadOriginErr, _         = primitives.NewApplyExtrinsicResult(dispatchOutcomeBadOriginErr)
+	applyExtrinsicResultBadProofErr, _          = primitives.NewApplyExtrinsicResult(invalidTransactionBadProofErr)
+
+	applyExtrinsicResultCustomModuleErr, _       = primitives.NewApplyExtrinsicResult(dispatchOutcomeCustomModuleErr)
+	applyExtrinsicResultExistentialDepositErr, _ = primitives.NewApplyExtrinsicResult(dispatchOutcomeExistentialDepositErr)
+	applyExtrinsicResultKeepAliveErr, _          = primitives.NewApplyExtrinsicResult(dispatchOutcomeKeepAliveErr)
 )
 
 func newTestRuntime(t *testing.T) (*wazero_runtime.Instance, *runtime.Storage) {

--- a/runtime/validate_transaction_test.go
+++ b/runtime/validate_transaction_test.go
@@ -191,14 +191,7 @@ func Test_ValidateTransaction_StaleError_InvalidNonce(t *testing.T) {
 	transactionValidityResult, err := primitives.DecodeTransactionValidityResult(buffer)
 	assert.Nil(t, err)
 
-	assert.Equal(t,
-		primitives.NewTransactionValidityResult(
-			primitives.NewTransactionValidityError(
-				primitives.NewInvalidTransactionStale(),
-			),
-		),
-		transactionValidityResult,
-	)
+	assert.Equal(t, transactionValidityResultStaleErr, transactionValidityResult)
 }
 
 func Test_ValidateTransaction_ExhaustsResourcesError(t *testing.T) {
@@ -260,14 +253,7 @@ func Test_ValidateTransaction_ExhaustsResourcesError(t *testing.T) {
 	transactionValidityResult, err := primitives.DecodeTransactionValidityResult(buffer)
 	assert.Nil(t, err)
 
-	assert.Equal(t,
-		primitives.NewTransactionValidityResult(
-			primitives.NewTransactionValidityError(
-				primitives.NewInvalidTransactionExhaustsResources(),
-			),
-		),
-		transactionValidityResult,
-	)
+	assert.Equal(t, transactionValidityResultExhaustsResourcesErr, transactionValidityResult)
 }
 
 func Test_ValidateTransaction_Era(t *testing.T) {
@@ -345,7 +331,10 @@ func Test_ValidateTransaction_Era(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, true, transactionValidityResult.IsValidTransaction())
-	assert.Equal(t, sc.U64(15), transactionValidityResult.AsValidTransaction().Longevity)
+
+	validTransaction, err := transactionValidityResult.AsValidTransaction()
+	assert.NoError(t, err)
+	assert.Equal(t, sc.U64(15), validTransaction.Longevity)
 }
 
 func Test_ValidateTransaction_NoUnsignedValidator(t *testing.T) {
@@ -412,14 +401,7 @@ func Test_ValidateTransaction_NoUnsignedValidator(t *testing.T) {
 			res, err := rt.Exec("TaggedTransactionQueue_validate_transaction", buffer.Bytes())
 
 			assert.NoError(t, err)
-			assert.Equal(t,
-				primitives.NewTransactionValidityResult(
-					primitives.NewTransactionValidityError(
-						primitives.NewUnknownTransactionNoUnsignedValidator(),
-					),
-				).Bytes(),
-				res,
-			)
+			assert.Equal(t, transactionValidityResultNoUnsignedValidatorErr.Bytes(), res)
 		})
 	}
 }
@@ -453,13 +435,5 @@ func Test_ValidateTransaction_MandatoryValidation_Timestamp(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.NoError(t, err)
-	assert.Equal(
-		t,
-		primitives.NewTransactionValidityResult(
-			primitives.NewTransactionValidityError(
-				primitives.NewInvalidTransactionMandatoryValidation(),
-			),
-		).Bytes(),
-		res,
-	)
+	assert.Equal(t, transactionValidityResultMandatoryValidationErr.Bytes(), res)
 }


### PR DESCRIPTION
**Detailed description**:

**Which issue(s) this PR fixes**:
Fixes #262 

**Special notes for your reviewer**:

TODO remove logging from `Encode` methods

**Checklist**
- [ ] Documentation added
- [x] Tests updated