### PR TITLE
ci: bump versions; remove unnecessary executable for device space

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,18 +8,18 @@ jobs:
   tests-coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Setup GO env
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: '1.21'
           cache: true
       - name: Run Unit Tests with Coverage
         run: make test-coverage
       - name: Upload Coverage to CodeCov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout master
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python env
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
       

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,13 +11,16 @@ jobs:
   build-and-run-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Remove unnecessary files
+        run: |
+          sudo rm -rf /usr/local/lib/android
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Build Runtime using Docker
         run: make build-docker-benchmarking
       - name: Setup GO env
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: '1.21'
           cache: true


### PR DESCRIPTION
**Detailed description**:
* TinyGo image build is large enough to make the Github Action fail with `no space left on device`.
* Remove android pre-build executable - 9GB
* Bump Actions versions to latest

**Which issue(s) this PR fixes**:
Fixes #None

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated